### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/811/421168811.geojson
+++ b/data/421/168/811/421168811.geojson
@@ -640,6 +640,9 @@
     ],
     "wof:country":"PK",
     "wof:created":1459008781,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb57215ffb0d33f230972d6d1a087660",
     "wof:hierarchy":[
         {
@@ -650,7 +653,7 @@
         }
     ],
     "wof:id":421168811,
-    "wof:lastmodified":1566591764,
+    "wof:lastmodified":1582351712,
     "wof:name":"Islamabad",
     "wof:parent_id":85675741,
     "wof:placetype":"locality",

--- a/data/421/191/101/421191101.geojson
+++ b/data/421/191/101/421191101.geojson
@@ -617,6 +617,9 @@
     ],
     "wof:country":"PK",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13421a973a125d9fcb8d8524ab9a76db",
     "wof:hierarchy":[
         {
@@ -628,7 +631,7 @@
         }
     ],
     "wof:id":421191101,
-    "wof:lastmodified":1578100509,
+    "wof:lastmodified":1582351713,
     "wof:megacity":1,
     "wof:name":"Karachi",
     "wof:parent_id":1108692233,

--- a/data/421/195/141/421195141.geojson
+++ b/data/421/195/141/421195141.geojson
@@ -192,6 +192,9 @@
     },
     "wof:country":"PK",
     "wof:created":1459009833,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"54d4ed7fb9a613a0bc87c9756bb00825",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421195141,
-    "wof:lastmodified":1566591767,
+    "wof:lastmodified":1582351712,
     "wof:name":"Saidu",
     "wof:parent_id":1108692399,
     "wof:placetype":"locality",

--- a/data/421/202/485/421202485.geojson
+++ b/data/421/202/485/421202485.geojson
@@ -345,6 +345,9 @@
     },
     "wof:country":"PK",
     "wof:created":1459010119,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0dcbf174f57e7717c97e213f6a19073b",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
         }
     ],
     "wof:id":421202485,
-    "wof:lastmodified":1561789999,
+    "wof:lastmodified":1582351712,
     "wof:name":"Abbottabad",
     "wof:parent_id":85675763,
     "wof:placetype":"locality",

--- a/data/856/326/59/85632659.geojson
+++ b/data/856/326/59/85632659.geojson
@@ -1047,6 +1047,11 @@
     },
     "wof:country":"PK",
     "wof:country_alpha3":"PAK",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"63ac3923cdb8df98556122c8f647764b",
     "wof:hierarchy":[
         {
@@ -1063,7 +1068,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1566584922,
+    "wof:lastmodified":1582351429,
     "wof:name":"Pakistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/757/35/85675735.geojson
+++ b/data/856/757/35/85675735.geojson
@@ -383,6 +383,9 @@
         "wof:belongsto"
     ],
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fad1af1f416a90525cc4e42b2919cc1",
     "wof:hierarchy":[
         {
@@ -407,7 +410,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1566584919,
+    "wof:lastmodified":1582351428,
     "wof:name":"Azad Kashmir",
     "wof:parent_id":1159339497,
     "wof:placetype":"region",

--- a/data/856/757/45/85675745.geojson
+++ b/data/856/757/45/85675745.geojson
@@ -350,6 +350,9 @@
         "wk:page":"Gilgit-Baltistan"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75ad44457ddd098bbbbe86a8b303a1b7",
     "wof:hierarchy":[
         {
@@ -374,7 +377,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1566584920,
+    "wof:lastmodified":1582351428,
     "wof:name":"Gilgit-Baltistan",
     "wof:parent_id":1159339495,
     "wof:placetype":"region",

--- a/data/859/036/53/85903653.geojson
+++ b/data/859/036/53/85903653.geojson
@@ -68,6 +68,9 @@
         "gp:id":2189822
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4488ee74b0149eeec46cca882e6f99e3",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566584915,
+    "wof:lastmodified":1582351427,
     "wof:name":"Abdarra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/55/85903655.geojson
+++ b/data/859/036/55/85903655.geojson
@@ -81,6 +81,9 @@
         "qs:id":59317
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"16c9943babcaa59dded73b11b9cb015b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1534379407,
+    "wof:lastmodified":1582351427,
     "wof:name":"\u00c5dra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/57/85903657.geojson
+++ b/data/859/036/57/85903657.geojson
@@ -116,11 +116,11 @@
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":1135,
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -129,6 +129,9 @@
         "qs_pg:id":1117329
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eec01dc2fa247dec1eb66f2375b49a32",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086870,
+    "wof:lastmodified":1582351426,
     "wof:name":"Arambagh",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/61/85903661.geojson
+++ b/data/859/036/61/85903661.geojson
@@ -71,6 +71,9 @@
         "gp:id":2190610
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dae9f351d41600d8f4638fcac8f21283",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584913,
+    "wof:lastmodified":1582351426,
     "wof:name":"\u00c5rya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/63/85903663.geojson
+++ b/data/859/036/63/85903663.geojson
@@ -106,6 +106,9 @@
         "qs_pg:id":1221776
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a314dbc0ca2b13f5e6f0a6fe00ec98a8",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Bh\u00e5na M\u00e5ri",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/65/85903665.geojson
+++ b/data/859/036/65/85903665.geojson
@@ -82,11 +82,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -95,6 +95,9 @@
         "qs_pg:id":959515
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca6f70a83610168f29f8db81b80164b1",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086870,
+    "wof:lastmodified":1582351427,
     "wof:name":"Bhurtpur Barracks",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/67/85903667.geojson
+++ b/data/859/036/67/85903667.geojson
@@ -263,6 +263,9 @@
         "wd:id":"Q865588"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee59b470dedd1fb2a78f4e5b5a87f409",
     "wof:hierarchy":[
         {
@@ -278,7 +281,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566584914,
+    "wof:lastmodified":1582351427,
     "wof:name":"Committee",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/69/85903669.geojson
+++ b/data/859/036/69/85903669.geojson
@@ -74,6 +74,9 @@
         "qs:id":222754
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77e0ba7ddb5acb1a85fb4ff75d430a62",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379407,
+    "wof:lastmodified":1582351427,
     "wof:name":"Dhobi Mandi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/71/85903671.geojson
+++ b/data/859/036/71/85903671.geojson
@@ -62,11 +62,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -74,6 +74,9 @@
         "qs_pg:id":1130099
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d663257c0861c77e1af825dc0c6e2c24",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351427,
     "wof:name":"Farooq-i-Azam Lines",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/73/85903673.geojson
+++ b/data/859/036/73/85903673.geojson
@@ -61,17 +61,20 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":2195974
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9b41d471b2e685e3957600e55aacb98",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1578086871,
+    "wof:lastmodified":1582351427,
     "wof:name":"G\u00e5nji",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/75/85903675.geojson
+++ b/data/859/036/75/85903675.geojson
@@ -64,17 +64,20 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":2196979
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4188bc693fccdc4cb208f888dfd9d7f8",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351427,
     "wof:name":"Goth Th\u00e5ra",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/79/85903679.geojson
+++ b/data/859/036/79/85903679.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":1130102
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9270427d26c2baba7b4e3a26ac96aa6e",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Gw\u00e5l Mandi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/81/85903681.geojson
+++ b/data/859/036/81/85903681.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Ichhra"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1889bb25961b0b6d905fcca4fc46477",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566584915,
+    "wof:lastmodified":1582351427,
     "wof:name":"Ichhra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/83/85903683.geojson
+++ b/data/859/036/83/85903683.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":894047
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9937f68d0dd1650a641410df420b71b",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Im\u00e5m B\u00e5ra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/85/85903685.geojson
+++ b/data/859/036/85/85903685.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q6190834"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8acaf5438edaf7a100dc76277e72a055",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Jhanda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/87/85903687.geojson
+++ b/data/859/036/87/85903687.geojson
@@ -74,6 +74,9 @@
         "qs:id":235524
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"275a4453261d8f389fe1faefbe8f43e9",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379406,
+    "wof:lastmodified":1582351427,
     "wof:name":"Juna Market",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/89/85903689.geojson
+++ b/data/859/036/89/85903689.geojson
@@ -100,11 +100,11 @@
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":122,
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -115,6 +115,9 @@
         "wk:page":"Kiamari"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36f282a0dbd79c75e75e663a081d9fe2",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351427,
     "wof:name":"Kiam\u00e5ri",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/91/85903691.geojson
+++ b/data/859/036/91/85903691.geojson
@@ -87,6 +87,9 @@
         "qs:id":1168423
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ae33069fcb3a0a459f999c82096c7c4",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1534379407,
+    "wof:lastmodified":1582351427,
     "wof:name":"L\u00e5lkurti B\u00e5z\u00e5r",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/93/85903693.geojson
+++ b/data/859/036/93/85903693.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":235525
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36e9f0bbfedb1955271f5fe17640a1de",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566584914,
+    "wof:lastmodified":1582351427,
     "wof:name":"Mozang",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/97/85903697.geojson
+++ b/data/859/036/97/85903697.geojson
@@ -75,6 +75,9 @@
         "qs:id":1168428
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"698cc675a6bf34f096ad5f7ed7ad0c2c",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379407,
+    "wof:lastmodified":1582351427,
     "wof:name":"Naulakha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/036/99/85903699.geojson
+++ b/data/859/036/99/85903699.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":1130142
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa9f2c2736c3bf1f764bb741b8eec0a1",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584915,
+    "wof:lastmodified":1582351427,
     "wof:name":"Nautheh\u00e5n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/01/85903701.geojson
+++ b/data/859/037/01/85903701.geojson
@@ -63,11 +63,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -76,6 +76,9 @@
         "qs_pg:id":1168430
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf60e77c29ff26b8171b969945085e36",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351427,
     "wof:name":"Nawa\u00e5b\u00e5d",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/03/85903703.geojson
+++ b/data/859/037/03/85903703.geojson
@@ -75,6 +75,9 @@
         "wd:id":"Q7267727"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08f0e51dcfb2f70d9a22ad8641ad1b9e",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Qila Gujar Singh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/05/85903705.geojson
+++ b/data/859/037/05/85903705.geojson
@@ -77,6 +77,9 @@
         "qs:id":1117331
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f55f836ec6debace0df4251f667a634b",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379407,
+    "wof:lastmodified":1582351427,
     "wof:name":"Ramgali",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/07/85903707.geojson
+++ b/data/859/037/07/85903707.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":894048
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd04fb47fbbaa0ea830b41c393a60e8d",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Ratta Amr\u00e5l",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/09/85903709.geojson
+++ b/data/859/037/09/85903709.geojson
@@ -90,17 +90,20 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":2206907
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"711ae6ee3610fd4e48131d22bdc1a74e",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351427,
     "wof:name":"Sadr",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/11/85903711.geojson
+++ b/data/859/037/11/85903711.geojson
@@ -82,6 +82,9 @@
         "qs_pg:id":44589
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ce946bab6db867bf6e9c860df568068",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"Sadr B\u00e5z\u00e5r",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/15/85903715.geojson
+++ b/data/859/037/15/85903715.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":222764
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68ee2b04323ab2cbedf403c18920a4ab",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584917,
+    "wof:lastmodified":1582351427,
     "wof:name":"Sadr B\u00e5z\u00e5r",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/17/85903717.geojson
+++ b/data/859/037/17/85903717.geojson
@@ -84,6 +84,9 @@
         "qs_pg:id":1130176
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"018dd98c2802a1b76ce8f0db7991f892",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584916,
+    "wof:lastmodified":1582351427,
     "wof:name":"West Ridge B\u00e5z\u00e5r",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/75/85907575.geojson
+++ b/data/859/075/75/85907575.geojson
@@ -63,11 +63,11 @@
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":283,
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,6 +78,9 @@
         "wk:page":"Saddar"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae7f6e36a99deaa6cde77cf7b376bbc4",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086867,
+    "wof:lastmodified":1582351428,
     "wof:name":"Saddar",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/77/85907577.geojson
+++ b/data/859/075/77/85907577.geojson
@@ -363,6 +363,9 @@
         "wd:id":"Q7398825"
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38f1c37d779e5ef44969363bde05d2a6",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578100513,
+    "wof:lastmodified":1582351428,
     "wof:name":"Pechs",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/79/85907579.geojson
+++ b/data/859/075/79/85907579.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -73,6 +73,9 @@
         "qs_pg:id":985264
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1fd4cdee4523ca015ee00fa171eaadd",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351428,
     "wof:name":"Defence Housing Colony",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/81/85907581.geojson
+++ b/data/859/075/81/85907581.geojson
@@ -71,6 +71,9 @@
         "qs:id":985264
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b4bbb8d058bc3fa498b6e9aba2c9633",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379407,
+    "wof:lastmodified":1582351428,
     "wof:name":"Defence Housing Colony",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/85/85907585.geojson
+++ b/data/859/075/85/85907585.geojson
@@ -64,11 +64,11 @@
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":32,
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -76,6 +76,9 @@
         "qs_pg:id":347124
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07f8f3d940c9ef7f177813e8ed437bf4",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351428,
     "wof:name":"Clifton Beach",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/87/85907587.geojson
+++ b/data/859/075/87/85907587.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":985265
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b51522500f37559306067f3897984494",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351427,
     "wof:name":"Patel-ka-bara",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/89/85907589.geojson
+++ b/data/859/075/89/85907589.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":238891
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c8ee895169757adadbfa23f2231d1ac",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351427,
     "wof:name":"Lorens-road",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/91/85907591.geojson
+++ b/data/859/075/91/85907591.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":1085682
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd5a988c98bba0fe52cc620055d4b898",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351428,
     "wof:name":"Runchor",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/93/85907593.geojson
+++ b/data/859/075/93/85907593.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":1085683
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed1da7f9f32147d0a906871af6f00b62",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086868,
+    "wof:lastmodified":1582351427,
     "wof:name":"Karachi City Centre",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/95/85907595.geojson
+++ b/data/859/075/95/85907595.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":1031264
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af14beea595ce1756b1f37ca5a24b1e2",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351427,
     "wof:name":"Bizerta",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/97/85907597.geojson
+++ b/data/859/075/97/85907597.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":14564
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db976ae87be598905935e3d4393476c9",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351428,
     "wof:name":"Frir-hall",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/859/075/99/85907599.geojson
+++ b/data/859/075/99/85907599.geojson
@@ -57,11 +57,11 @@
     ],
     "src:lbl_centroid":"yerbashapes",
     "wof:belongsto":[
+        85675757,
         102191569,
         85632659,
         421191101,
-        1108692233,
-        85675757
+        1108692233
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -69,6 +69,9 @@
         "qs_pg:id":366872
     },
     "wof:country":"PK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2050f4c257513b2bba932b4dc299931",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1578086869,
+    "wof:lastmodified":1582351428,
     "wof:name":"Goth-khadgi-lemun-khan",
     "wof:parent_id":421191101,
     "wof:placetype":"neighbourhood",

--- a/data/890/420/091/890420091.geojson
+++ b/data/890/420/091/890420091.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PK",
     "wof:created":1469051317,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97ce4a68d8f543d80b3b4fe1d00026aa",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890420091,
-    "wof:lastmodified":1566591800,
+    "wof:lastmodified":1582351714,
     "wof:name":"Loralai",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/890/422/345/890422345.geojson
+++ b/data/890/422/345/890422345.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"PK",
     "wof:created":1469051438,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff3934462b3affec437f5ab9edd80df9",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":890422345,
-    "wof:lastmodified":1566591793,
+    "wof:lastmodified":1582351713,
     "wof:name":"North Waziristan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/890/438/109/890438109.geojson
+++ b/data/890/438/109/890438109.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"PK",
     "wof:created":1469052180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9c8dc437020498442bc7c213852ef44",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":890438109,
-    "wof:lastmodified":1566591799,
+    "wof:lastmodified":1582351714,
     "wof:name":"Quetta",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/890/455/843/890455843.geojson
+++ b/data/890/455/843/890455843.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"PK",
     "wof:created":1469052977,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82e692f06c40a54d20ccec0d1deed7e2",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890455843,
-    "wof:lastmodified":1566591796,
+    "wof:lastmodified":1582351714,
     "wof:name":"Zhob",
     "wof:parent_id":85675733,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.