### PR TITLE
pk concordances, placetype local, and more

### DIFF
--- a/data/110/869/211/5/1108692115.geojson
+++ b/data/110/869/211/5/1108692115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.16796,
-    "geom:area_square_m":1719593969.057438,
+    "geom:area_square_m":1719594140.241402,
     "geom:bbox":"72.981302,33.809837,73.510649,34.372122",
     "geom:latitude":34.108382,
     "geom:longitude":73.270422,
@@ -131,9 +131,10 @@
         "hasc:id":"PK.NW.HZ",
         "wd:id":"Q306799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319766,
-    "wof:geomhash":"470eb9e1c598c96d3c94221423abcc0d",
+    "wof:geomhash":"aca54f0bbbeaf9af2cb3ae637e0a3a7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108692115,
-    "wof:lastmodified":1690854181,
+    "wof:lastmodified":1695886667,
     "wof:name":"Abbottabad",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/211/9/1108692119.geojson
+++ b/data/110/869/211/9/1108692119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.669472,
-    "geom:area_square_m":6903448593.692526,
+    "geom:area_square_m":6903448593.692461,
     "geom:bbox":"71.7050877203,32.9914520247,72.9281869011,34.0042814198",
     "geom:latitude":33.494091,
     "geom:longitude":72.312746,
@@ -130,9 +130,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.RP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319767,
-    "wof:geomhash":"0a82283f230206373ef24e70818f1a1c",
+    "wof:geomhash":"cb338a45a56812cdb80c6f8bd4b5791c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108692119,
-    "wof:lastmodified":1566590149,
+    "wof:lastmodified":1695886667,
     "wof:name":"Attock",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/212/1/1108692121.geojson
+++ b/data/110/869/212/1/1108692121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.240282,
-    "geom:area_square_m":24854521712.341755,
+    "geom:area_square_m":24854521401.413406,
     "geom:bbox":"64.126221,25.405953,66.26506,27.431741",
     "geom:latitude":26.200519,
     "geom:longitude":65.387691,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q250800"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319769,
-    "wof:geomhash":"f75802e4b6f17bd3175be52f6bec1afd",
+    "wof:geomhash":"5445ffce459c44dd1d7bd8d807f327f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692121,
-    "wof:lastmodified":1690854189,
+    "wof:lastmodified":1695886669,
     "wof:name":"Awaran",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/212/3/1108692123.geojson
+++ b/data/110/869/212/3/1108692123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.600021,
-    "geom:area_square_m":6738939012.273108,
+    "geom:area_square_m":6738939012.273117,
     "geom:bbox":"68.3464236089,24.212,69.3302163139,25.2990171881",
     "geom:latitude":24.728916,
     "geom:longitude":68.844326,
@@ -107,9 +107,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2347462"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319770,
-    "wof:geomhash":"03a9fdfdbc784a6e7f11128792fb0082",
+    "wof:geomhash":"0068db0ec9510f558b2f879ef6942e9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108692123,
-    "wof:lastmodified":1566590161,
+    "wof:lastmodified":1695886670,
     "wof:name":"Badin",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/212/5/1108692125.geojson
+++ b/data/110/869/212/5/1108692125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121439,
-    "geom:area_square_m":1245347280.085035,
+    "geom:area_square_m":1245346461.574867,
     "geom:bbox":"73.476905,33.811631,74.282214,34.123286",
     "geom:latitude":33.968969,
     "geom:longitude":73.898057,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319772,
-    "wof:geomhash":"684bee80d2e1d3f0ee1ae38f789f68d9",
+    "wof:geomhash":"1dbc04a18355b80a158556e9d3a76589",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692125,
-    "wof:lastmodified":1627522512,
+    "wof:lastmodified":1695886154,
     "wof:name":"Bagh",
     "wof:parent_id":85675735,
     "wof:placetype":"county",

--- a/data/110/869/212/7/1108692127.geojson
+++ b/data/110/869/212/7/1108692127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.792614,
-    "geom:area_square_m":8521364018.059011,
+    "geom:area_square_m":8521364018.058531,
     "geom:bbox":"72.265086789,28.818283347,73.972585,30.3385253881",
     "geom:latitude":29.602624,
     "geom:longitude":73.016404,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319773,
-    "wof:geomhash":"c66eccb7aecc4ee18be9ee3720d0b211",
+    "wof:geomhash":"c4357475a0a9f73005559198526eda1a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108692127,
-    "wof:lastmodified":1566590161,
+    "wof:lastmodified":1695886670,
     "wof:name":"Bahawalnagar",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/212/9/1108692129.geojson
+++ b/data/110/869/212/9/1108692129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.213691,
-    "geom:area_square_m":23978827102.603207,
+    "geom:area_square_m":23978829076.849617,
     "geom:bbox":"70.878621,27.796661,72.746776,29.856468",
     "geom:latitude":28.831259,
     "geom:longitude":71.723983,
@@ -127,9 +127,10 @@
         "hasc:id":"PK.PB.BW",
         "wd:id":"Q2281250"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319775,
-    "wof:geomhash":"d19d8a8c196209c159ef7deea3a266f9",
+    "wof:geomhash":"5722a2b7109803ea2b24369035c4b57f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692129,
-    "wof:lastmodified":1690854189,
+    "wof:lastmodified":1695886670,
     "wof:name":"Bahawalpur",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/213/1/1108692131.geojson
+++ b/data/110/869/213/1/1108692131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134961,
-    "geom:area_square_m":1371137350.76021,
+    "geom:area_square_m":1371137240.975506,
     "geom:bbox":"71.172861,34.508299,71.799784,34.977945",
     "geom:latitude":34.752732,
     "geom:longitude":71.504713,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319777,
-    "wof:geomhash":"50adc60a8fc4957727bb3f95e3d3c107",
+    "wof:geomhash":"b4285a667056579bc192a4db4b56e646",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108692131,
-    "wof:lastmodified":1627522512,
+    "wof:lastmodified":1695886155,
     "wof:name":"Bajaur",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/213/3/1108692133.geojson
+++ b/data/110/869/213/3/1108692133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.827961,
-    "geom:area_square_m":18425393869.919506,
+    "geom:area_square_m":18425393869.920536,
     "geom:bbox":"74.7789465883,34.51061,76.8088377486,36.2484556208",
     "geom:latitude":35.393212,
     "geom:longitude":75.679978,
@@ -131,9 +131,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319778,
-    "wof:geomhash":"f6d1324ae224dcef0f7c1b1dd75d91db",
+    "wof:geomhash":"d2ac1aaa9ef8ac47ac5fc5e574aeb22f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108692133,
-    "wof:lastmodified":1566590169,
+    "wof:lastmodified":1695886673,
     "wof:name":"Baltistan",
     "wof:parent_id":85675745,
     "wof:placetype":"county",

--- a/data/110/869/213/7/1108692137.geojson
+++ b/data/110/869/213/7/1108692137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116116,
-    "geom:area_square_m":1205182419.21121,
+    "geom:area_square_m":1205182288.953976,
     "geom:bbox":"70.374924,32.716874,70.96587,33.099765",
     "geom:latitude":32.924578,
     "geom:longitude":70.658612,
@@ -130,9 +130,10 @@
         "hasc:id":"PK.NW.BN",
         "wd:id":"Q3030995"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319779,
-    "wof:geomhash":"235aa936aa574f4a06da1966e475d5bf",
+    "wof:geomhash":"d54c5f47f0b490655a605b344683683f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108692137,
-    "wof:lastmodified":1690854194,
+    "wof:lastmodified":1695886042,
     "wof:name":"Bannu",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/213/9/1108692139.geojson
+++ b/data/110/869/213/9/1108692139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.316905,
-    "geom:area_square_m":3395062147.592293,
+    "geom:area_square_m":3395062234.709486,
     "geom:bbox":"69.063874,29.60242,70.072595,30.378721",
     "geom:latitude":29.956818,
     "geom:longitude":69.623811,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.BA.ZH",
         "wd:id":"Q250810"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319781,
-    "wof:geomhash":"e676dda867fd4575667ea253d81b6b4f",
+    "wof:geomhash":"9e154843cde0c3e403dd580e93cbab18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692139,
-    "wof:lastmodified":1690854194,
+    "wof:lastmodified":1695886673,
     "wof:name":"Barkhan",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/214/1/1108692141.geojson
+++ b/data/110/869/214/1/1108692141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135792,
-    "geom:area_square_m":1378922961.560352,
+    "geom:area_square_m":1378923124.403036,
     "geom:bbox":"72.867034,34.559533,73.494175,34.966772",
     "geom:latitude":34.791582,
     "geom:longitude":73.124094,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.HZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319782,
-    "wof:geomhash":"70341f6b4c92a990c8301a99cadbb39e",
+    "wof:geomhash":"45c5a765109e68102d8d5d6c1923686a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692141,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886155,
     "wof:name":"Batagram",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/214/3/1108692143.geojson
+++ b/data/110/869/214/3/1108692143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.811335,
-    "geom:area_square_m":8539976265.90464,
+    "geom:area_square_m":8539976265.904667,
     "geom:bbox":"70.7932903786,31.1387138083,72.0258624991,32.2143863261",
     "geom:latitude":31.651398,
     "geom:longitude":71.427613,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319784,
-    "wof:geomhash":"35a24353ad80e19e0e76b64c1816ec6e",
+    "wof:geomhash":"eed212e37ae68cb2094e8cba22efb587",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692143,
-    "wof:lastmodified":1566590168,
+    "wof:lastmodified":1695886672,
     "wof:name":"Bhakkar",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/214/5/1108692145.geojson
+++ b/data/110/869/214/5/1108692145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169924,
-    "geom:area_square_m":1732275934.606661,
+    "geom:area_square_m":1732275137.921638,
     "geom:bbox":"72.205747,34.166114,72.771242,34.71771",
     "geom:latitude":34.467747,
     "geom:longitude":72.517742,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319785,
-    "wof:geomhash":"45dfb8fcd1e56e42c9d8e3a705929954",
+    "wof:geomhash":"76e3a274201590c05b1e2944003401c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692145,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886155,
     "wof:name":"Buner",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/214/7/1108692147.geojson
+++ b/data/110/869/214/7/1108692147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.097199,
-    "geom:area_square_m":44319374122.366745,
+    "geom:area_square_m":44319373082.434807,
     "geom:bbox":"60.872972,27.898732,65.47882,29.858472",
     "geom:latitude":28.977449,
     "geom:longitude":63.272638,
@@ -119,9 +119,10 @@
         "hasc:id":"PK.BA.QE",
         "wd:id":"Q276717"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319787,
-    "wof:geomhash":"56d6fccdfb1fc0034968e596a74a684e",
+    "wof:geomhash":"9ecd514b949aad8a40bacf4de3412ded",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108692147,
-    "wof:lastmodified":1690854194,
+    "wof:lastmodified":1695886672,
     "wof:name":"Chagai",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/214/9/1108692149.geojson
+++ b/data/110/869/214/9/1108692149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.636614,
-    "geom:area_square_m":6609296021.150242,
+    "geom:area_square_m":6609296021.150536,
     "geom:bbox":"71.7613121337,32.5333295111,73.2576387208,33.2247613344",
     "geom:latitude":32.900684,
     "geom:longitude":72.531468,
@@ -115,9 +115,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.RP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319788,
-    "wof:geomhash":"bce55637d9ba9017211df338579f9035",
+    "wof:geomhash":"f6e07fcf0a02de66ae7530fcfab791dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108692149,
-    "wof:lastmodified":1566590168,
+    "wof:lastmodified":1695886673,
     "wof:name":"Chakwal",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/215/1/1108692151.geojson
+++ b/data/110/869/215/1/1108692151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096154,
-    "geom:area_square_m":982868742.488127,
+    "geom:area_square_m":982868881.612993,
     "geom:bbox":"71.465279,34.045891,71.935222,34.452774",
     "geom:latitude":34.242262,
     "geom:longitude":71.71822,
@@ -126,9 +126,10 @@
         "hasc:id":"PK.NW.PS",
         "wd:id":"Q549467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319790,
-    "wof:geomhash":"735be62d6a5ab56a2418178077e73d2c",
+    "wof:geomhash":"4d0356ce300c7d4c817122ca7772d0bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108692151,
-    "wof:lastmodified":1690854190,
+    "wof:lastmodified":1695886670,
     "wof:name":"Charsadda",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/215/5/1108692155.geojson
+++ b/data/110/869/215/5/1108692155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251416,
-    "geom:area_square_m":2646068586.379663,
+    "geom:area_square_m":2646067618.024403,
     "geom:bbox":"72.417903,31.350294,73.247454,31.984314",
     "geom:latitude":31.66244,
     "geom:longitude":72.821795,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.FS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319791,
-    "wof:geomhash":"ffc9297558064ae4cf4ca1325f780862",
+    "wof:geomhash":"5507e20e924fcffc99054a32a896bafa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108692155,
-    "wof:lastmodified":1636502017,
+    "wof:lastmodified":1695886042,
     "wof:name":"Chiniot",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/215/7/1108692157.geojson
+++ b/data/110/869/215/7/1108692157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.463929,
-    "geom:area_square_m":14602133849.689234,
+    "geom:area_square_m":14602133849.686739,
     "geom:bbox":"71.195027,35.22213,73.869454898,36.9100271547",
     "geom:latitude":36.226466,
     "geom:longitude":72.225772,
@@ -130,9 +130,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319792,
-    "wof:geomhash":"14c24530cc58c294500dc2d3728d3aa0",
+    "wof:geomhash":"94f1308a2b12f2f74104ae8d412f87ee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108692157,
-    "wof:lastmodified":1566590162,
+    "wof:lastmodified":1695886670,
     "wof:name":"Chitral",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/215/9/1108692159.geojson
+++ b/data/110/869/215/9/1108692159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.717591,
-    "geom:area_square_m":7915154628.922897,
+    "geom:area_square_m":7915152517.296453,
     "geom:bbox":"67.130378,26.085097,68.040768,27.443696",
     "geom:latitude":26.86855,
     "geom:longitude":67.501857,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q1082679"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319794,
-    "wof:geomhash":"c61c5d2f0a960b631f59db6d37ebdc3d",
+    "wof:geomhash":"f289acbbf92b58470d7a90b507bb8277",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692159,
-    "wof:lastmodified":1690854190,
+    "wof:lastmodified":1695886042,
     "wof:name":"Dadu",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/216/1/1108692161.geojson
+++ b/data/110/869/216/1/1108692161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.94767,
-    "geom:area_square_m":10253481396.866503,
+    "geom:area_square_m":10253482508.002407,
     "geom:bbox":"68.280952,28.418306,69.773867,29.679516",
     "geom:latitude":28.952778,
     "geom:longitude":69.048645,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319796,
-    "wof:geomhash":"2a5bb5cc2c3feb4efca8b8c6b493be93",
+    "wof:geomhash":"72732d7e341d10adc9c0f41a0653af05",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108692161,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886155,
     "wof:name":"Dera Bugti",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/216/3/1108692163.geojson
+++ b/data/110/869/216/3/1108692163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.097479,
-    "geom:area_square_m":11703609939.976135,
+    "geom:area_square_m":11703611899.62874,
     "geom:bbox":"69.875694,29.615126,70.889194,31.337072",
     "geom:latitude":30.407061,
     "geom:longitude":70.44435,
@@ -130,9 +130,10 @@
         "hasc:id":"PK.PB.GK",
         "wd:id":"Q2315476"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319797,
-    "wof:geomhash":"0323fb6ad9f9efa5b8827e6e19d9ee9a",
+    "wof:geomhash":"f7f7591ebfc541847bdcad328799712d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108692163,
-    "wof:lastmodified":1690854181,
+    "wof:lastmodified":1695886040,
     "wof:name":"Dera Ghazi Khan",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/216/5/1108692165.geojson
+++ b/data/110/869/216/5/1108692165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.705973,
-    "geom:area_square_m":7413095399.337408,
+    "geom:area_square_m":7413093974.149535,
     "geom:bbox":"70.161062,31.229912,71.354905,32.535045",
     "geom:latitude":31.873883,
     "geom:longitude":70.701903,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319798,
-    "wof:geomhash":"b02896df46bd95d295c9f29c3648d1ea",
+    "wof:geomhash":"3fd71a4d1dd98c63ff073e3283d9e0b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108692165,
-    "wof:lastmodified":1636502014,
+    "wof:lastmodified":1695886040,
     "wof:name":"Dera Ismail Khan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/216/7/1108692167.geojson
+++ b/data/110/869/216/7/1108692167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.319308,
-    "geom:area_square_m":13338004403.952351,
+    "geom:area_square_m":13338004192.089251,
     "geom:bbox":"73.117111,32.771474,75.267885,35.946053",
     "geom:latitude":35.147745,
     "geom:longitude":74.356915,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319800,
-    "wof:geomhash":"8fc3ca07608fbbedbd4a3103a54db922",
+    "wof:geomhash":"50888f71c7c19c5d2fb651d0cc383908",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108692167,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886155,
     "wof:name":"Diamir",
     "wof:parent_id":85675745,
     "wof:placetype":"county",

--- a/data/110/869/216/9/1108692169.geojson
+++ b/data/110/869/216/9/1108692169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.564461,
-    "geom:area_square_m":5967492190.300093,
+    "geom:area_square_m":5967493864.748257,
     "geom:bbox":"72.715013,30.676447,73.684175,31.788825",
     "geom:latitude":31.241348,
     "geom:longitude":73.152456,
@@ -130,9 +130,10 @@
         "hasc:id":"PK.PB.FS",
         "wd:id":"Q2281194"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319801,
-    "wof:geomhash":"06c60bca8e6f2697c2413ee9fb3ff300",
+    "wof:geomhash":"a24b635d0866ba0bd079c9e1ff92b165",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108692169,
-    "wof:lastmodified":1690854180,
+    "wof:lastmodified":1695886667,
     "wof:name":"Faisalabad",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/217/3/1108692173.geojson
+++ b/data/110/869/217/3/1108692173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078612,
-    "geom:area_square_m":814558847.903563,
+    "geom:area_square_m":814559503.833389,
     "geom:bbox":"70.257809,32.722868,70.872144,33.279168",
     "geom:latitude":33.072909,
     "geom:longitude":70.571128,
@@ -119,9 +119,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319803,
-    "wof:geomhash":"14c671a81865791da2a9926e64f098be",
+    "wof:geomhash":"7cc6ecb5e08f6ed69adc1e7b1b759921",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108692173,
-    "wof:lastmodified":1636502016,
+    "wof:lastmodified":1695886042,
     "wof:name":"Bannu",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/217/5/1108692175.geojson
+++ b/data/110/869/217/5/1108692175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169922,
-    "geom:area_square_m":1790013129.168352,
+    "geom:area_square_m":1790013613.195979,
     "geom:bbox":"69.896404,31.159311,70.445365,31.902412",
     "geom:latitude":31.577082,
     "geom:longitude":70.149503,
@@ -125,9 +125,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319804,
-    "wof:geomhash":"4bffa2135af753416844b04ac9bba215",
+    "wof:geomhash":"72df55165c9a8704b3aa60138be5ec99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108692175,
-    "wof:lastmodified":1636502016,
+    "wof:lastmodified":1695886042,
     "wof:name":"Dera Ismail Khan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/217/7/1108692177.geojson
+++ b/data/110/869/217/7/1108692177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051118,
-    "geom:area_square_m":526155305.505953,
+    "geom:area_square_m":526155156.515024,
     "geom:bbox":"71.350603,33.544663,71.839739,33.784433",
     "geom:latitude":33.653332,
     "geom:longitude":71.597979,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.NW.KH",
         "wd:id":"Q1250340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319806,
-    "wof:geomhash":"a3495f48546b51d4c0c085a8502189c6",
+    "wof:geomhash":"655cc16d7fdf5931c0ff8ea7ce883968",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692177,
-    "wof:lastmodified":1690854186,
+    "wof:lastmodified":1695886042,
     "wof:name":"Kohat",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/217/9/1108692179.geojson
+++ b/data/110/869/217/9/1108692179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017354,
-    "geom:area_square_m":180716355.714951,
+    "geom:area_square_m":180716355.714939,
     "geom:bbox":"70.2772138449,32.5666367105,70.5073190526,32.7470189979",
     "geom:latitude":32.630765,
     "geom:longitude":70.385876,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319807,
-    "wof:geomhash":"6caae2000795e60c808e6efe72ee87a9",
+    "wof:geomhash":"50cef064f40e72bff1769aa2e5d2cedb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108692179,
-    "wof:lastmodified":1566590155,
+    "wof:lastmodified":1695886668,
     "wof:name":"Lakki Marwat",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/218/1/1108692181.geojson
+++ b/data/110/869/218/1/1108692181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025506,
-    "geom:area_square_m":262277912.772113,
+    "geom:area_square_m":262277912.772069,
     "geom:bbox":"71.543131282,33.6477384049,71.8561946487,33.8408385113",
     "geom:latitude":33.737231,
     "geom:longitude":71.715817,
@@ -281,9 +281,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319808,
-    "wof:geomhash":"904bab83dcad0bde4ae78359160d3481",
+    "wof:geomhash":"991b8956f493ba32ce4f5d7fa93386e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -293,7 +294,7 @@
         }
     ],
     "wof:id":1108692181,
-    "wof:lastmodified":1566590151,
+    "wof:lastmodified":1695886667,
     "wof:name":"Peshawar",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/218/3/1108692183.geojson
+++ b/data/110/869/218/3/1108692183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111026,
-    "geom:area_square_m":1158454603.309397,
+    "geom:area_square_m":1158456674.979525,
     "geom:bbox":"70.052234,32.201363,70.607231,32.657761",
     "geom:latitude":32.453343,
     "geom:longitude":70.275464,
@@ -350,9 +350,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319810,
-    "wof:geomhash":"c2717cf275a6dfbe91771c861687bb84",
+    "wof:geomhash":"af63d57aa85ab98369cf3dc3928319ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -362,7 +363,7 @@
         }
     ],
     "wof:id":1108692183,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886158,
     "wof:name":"Tank",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/218/5/1108692185.geojson
+++ b/data/110/869/218/5/1108692185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.569954,
-    "geom:area_square_m":5755807704.39014,
+    "geom:area_square_m":5755809445.764601,
     "geom:bbox":"75.934282,34.749206,77.010453,35.676202",
     "geom:latitude":35.234899,
     "geom:longitude":76.485938,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319811,
-    "wof:geomhash":"19e21c3374e60ecd07fcc50ced207064",
+    "wof:geomhash":"bad6001ea59d5bee7d3fd1b0a93e749a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108692185,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886156,
     "wof:name":"Ghanche",
     "wof:parent_id":85675745,
     "wof:placetype":"county",

--- a/data/110/869/218/7/1108692187.geojson
+++ b/data/110/869/218/7/1108692187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.21656,
-    "geom:area_square_m":12125502311.823706,
+    "geom:area_square_m":12125502750.305861,
     "geom:bbox":"72.491689,35.771863,74.314596,36.925977",
     "geom:latitude":36.286793,
     "geom:longitude":73.42787,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319813,
-    "wof:geomhash":"95002156b58ad862cd404564df719c5a",
+    "wof:geomhash":"fd85b141a46dfe7bcc25968d49f12da3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108692187,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886156,
     "wof:name":"Ghizer",
     "wof:parent_id":85675745,
     "wof:placetype":"county",

--- a/data/110/869/219/1/1108692191.geojson
+++ b/data/110/869/219/1/1108692191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.583642,
-    "geom:area_square_m":6382653635.615761,
+    "geom:area_square_m":6382653183.300192,
     "geom:bbox":"69.150735,27.328802,70.168877,28.345246",
     "geom:latitude":27.820233,
     "geom:longitude":69.643451,
@@ -125,9 +125,10 @@
         "hasc:id":"PK.SD.SU",
         "wd:id":"Q2418935"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319814,
-    "wof:geomhash":"e1644120adf714c4d774cae5b927cc85",
+    "wof:geomhash":"9bde4878967fc5fc5010db66f9260761",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108692191,
-    "wof:lastmodified":1690854186,
+    "wof:lastmodified":1695886668,
     "wof:name":"Ghotki",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/219/3/1108692193.geojson
+++ b/data/110/869/219/3/1108692193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.838506,
-    "geom:area_square_m":18300692498.953239,
+    "geom:area_square_m":18300691927.555172,
     "geom:bbox":"73.934439,35.565587,76.061984,37.084107",
     "geom:latitude":36.387409,
     "geom:longitude":74.885618,
@@ -173,9 +173,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319816,
-    "wof:geomhash":"76bd6d023ba7c4f1ffc3e038721b90cf",
+    "wof:geomhash":"5d3d38902879b7e693a1e36f9fbde279",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":1108692193,
-    "wof:lastmodified":1636502015,
+    "wof:lastmodified":1695886041,
     "wof:name":"Gilgit",
     "wof:parent_id":85675745,
     "wof:placetype":"county",

--- a/data/110/869/219/5/1108692195.geojson
+++ b/data/110/869/219/5/1108692195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.349387,
-    "geom:area_square_m":3658178641.694532,
+    "geom:area_square_m":3658178330.575236,
     "geom:bbox":"73.666055,31.816818,74.571776,32.565517",
     "geom:latitude":32.139397,
     "geom:longitude":74.095096,
@@ -121,9 +121,10 @@
         "hasc:id":"PK.PB.GW",
         "wd:id":"Q2281238"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319817,
-    "wof:geomhash":"91e0ebcd8765e42ed347b6a4956026b1",
+    "wof:geomhash":"65a93a7364369bb80e39dc09e1bf822e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692195,
-    "wof:lastmodified":1690854186,
+    "wof:lastmodified":1695886668,
     "wof:name":"Gujranwala",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/219/7/1108692197.geojson
+++ b/data/110/869/219/7/1108692197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307831,
-    "geom:area_square_m":3202291354.072115,
+    "geom:area_square_m":3202291750.74885,
     "geom:bbox":"73.593707,32.375648,74.460332,33.034433",
     "geom:latitude":32.722868,
     "geom:longitude":73.995302,
@@ -153,9 +153,10 @@
         "hasc:id":"PK.PB.GW",
         "wd:id":"Q45303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319818,
-    "wof:geomhash":"fc458d893dbdc9eafdf9359bfb0b9e7e",
+    "wof:geomhash":"61e5786bfe0331cb54a528d7dfee3ee6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108692197,
-    "wof:lastmodified":1690854186,
+    "wof:lastmodified":1695886041,
     "wof:name":"Gujrat",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/219/9/1108692199.geojson
+++ b/data/110/869/219/9/1108692199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.04531,
-    "geom:area_square_m":11676191499.647562,
+    "geom:area_square_m":11676192089.495701,
     "geom:bbox":"61.617879,25.005362,65.241207,25.771397",
     "geom:latitude":25.398001,
     "geom:longitude":63.133387,
@@ -137,9 +137,10 @@
         "hasc:id":"PK.BA.MR",
         "wd:id":"Q2081818"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319820,
-    "wof:geomhash":"e8218142dbca2e10a994690b515858bf",
+    "wof:geomhash":"46c229dd2847a67e9b8a83a6af63705b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108692199,
-    "wof:lastmodified":1690854185,
+    "wof:lastmodified":1695886041,
     "wof:name":"Gwadar",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/220/1/1108692201.geojson
+++ b/data/110/869/220/1/1108692201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221654,
-    "geom:area_square_m":2323572842.314685,
+    "geom:area_square_m":2323572842.314576,
     "geom:bbox":"73.1538780204,31.7677353258,73.8260114621,32.3611492208",
     "geom:latitude":32.029622,
     "geom:longitude":73.510433,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.PB.GW",
         "wd:id":"Q2281213"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319821,
-    "wof:geomhash":"79321a19e64a175f4d09b3d296448014",
+    "wof:geomhash":"58907f67907530b9907caeb4cd4352e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692201,
-    "wof:lastmodified":1566590152,
+    "wof:lastmodified":1695886667,
     "wof:name":"Hafizabad",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/220/3/1108692203.geojson
+++ b/data/110/869/220/3/1108692203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133019,
-    "geom:area_square_m":1372732959.62151,
+    "geom:area_square_m":1372732645.801853,
     "geom:bbox":"70.495385,33.190829,71.222415,33.598753",
     "geom:latitude":33.427422,
     "geom:longitude":70.839946,
@@ -120,9 +120,10 @@
         "hasc:id":"PK.NW.KH",
         "wd:id":"Q1250340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319823,
-    "wof:geomhash":"c1348d052fee8d6fd817f7468c0f5874",
+    "wof:geomhash":"1f4fad0defbae8cc50c5a76e5d08ccab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108692203,
-    "wof:lastmodified":1690854183,
+    "wof:lastmodified":1695886041,
     "wof:name":"Hangu",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/220/5/1108692205.geojson
+++ b/data/110/869/220/5/1108692205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.184484,
-    "geom:area_square_m":1891025216.620488,
+    "geom:area_square_m":1891025216.620428,
     "geom:bbox":"72.5431358303,33.7341873359,73.220722592,34.362785072",
     "geom:latitude":34.007087,
     "geom:longitude":72.895685,
@@ -131,9 +131,10 @@
         "hasc:id":"PK.NW.HZ",
         "wd:id":"Q13410476"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319824,
-    "wof:geomhash":"42b02008c4cf4bd34c762903ca809612",
+    "wof:geomhash":"8ab7b53d6858bbad7727067b2aad1f41",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108692205,
-    "wof:lastmodified":1566590152,
+    "wof:lastmodified":1695886667,
     "wof:name":"Haripur",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/220/9/1108692209.geojson
+++ b/data/110/869/220/9/1108692209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285849,
-    "geom:area_square_m":3057096108.957926,
+    "geom:area_square_m":3057095361.139679,
     "geom:bbox":"67.226847,29.691905,68.431316,30.384297",
     "geom:latitude":30.127091,
     "geom:longitude":67.862625,
@@ -125,9 +125,10 @@
         "hasc:id":"PK.BA.SI",
         "wd:id":"Q2483088"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319826,
-    "wof:geomhash":"c1d54e8a9774bcb9f3e699958916a7eb",
+    "wof:geomhash":"a6551304ec8f5d5691a7aa43ac744316",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108692209,
-    "wof:lastmodified":1690854182,
+    "wof:lastmodified":1695886667,
     "wof:name":"Harnai",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/221/1/1108692211.geojson
+++ b/data/110/869/221/1/1108692211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088924,
-    "geom:area_square_m":993744120.854458,
+    "geom:area_square_m":993744348.503704,
     "geom:bbox":"68.296688,25.156118,68.639174,25.571191",
     "geom:latitude":25.343071,
     "geom:longitude":68.459597,
@@ -121,9 +121,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2419054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319827,
-    "wof:geomhash":"ebcfc911977121a363654e1e7b7a7e28",
+    "wof:geomhash":"cb21b3a9b8af5804b979d765496f375d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692211,
-    "wof:lastmodified":1690854184,
+    "wof:lastmodified":1695886668,
     "wof:name":"Hyderabad",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/221/5/1108692215.geojson
+++ b/data/110/869/221/5/1108692215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25854,
-    "geom:area_square_m":2817151201.234076,
+    "geom:area_square_m":2817150465.074545,
     "geom:bbox":"67.900998,27.926797,68.928821,28.472613",
     "geom:latitude":28.210411,
     "geom:longitude":68.486576,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.SD.LK",
         "wd:id":"Q32852"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319830,
-    "wof:geomhash":"502bd1bc7914c5ca8a5a8eada677b806",
+    "wof:geomhash":"c185fab4255dc116bfe6bb49c4c51dfa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692215,
-    "wof:lastmodified":1690854184,
+    "wof:lastmodified":1695886668,
     "wof:name":"Jacobabad",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/221/7/1108692217.geojson
+++ b/data/110/869/221/7/1108692217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.167099,
-    "geom:area_square_m":1820448126.983401,
+    "geom:area_square_m":1820449085.833786,
     "geom:bbox":"67.613504,27.913154,68.461913,28.630803",
     "geom:latitude":28.229694,
     "geom:longitude":68.029965,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319832,
-    "wof:geomhash":"86b1827fa17825c4d5e097d4c3b65327",
+    "wof:geomhash":"7607b1908f505f8dc2603c48132c453e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692217,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886156,
     "wof:name":"Jaffarabad",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/221/9/1108692219.geojson
+++ b/data/110/869/221/9/1108692219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.012059,
-    "geom:area_square_m":11272616845.26651,
+    "geom:area_square_m":11272615250.50164,
     "geom:bbox":"67.269311,24.970585,68.375171,26.606815",
     "geom:latitude":25.737025,
     "geom:longitude":67.792506,
@@ -110,9 +110,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q1082679"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319833,
-    "wof:geomhash":"5cccb72fb0a6dcf4b750fc5b67058a1b",
+    "wof:geomhash":"68b15affb465efe56887d35c0f3a4a58",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108692219,
-    "wof:lastmodified":1690854184,
+    "wof:lastmodified":1695886668,
     "wof:name":"Jamshoro",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/222/1/1108692221.geojson
+++ b/data/110/869/222/1/1108692221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.350745,
-    "geom:area_square_m":3814798196.68062,
+    "geom:area_square_m":3814798196.680454,
     "geom:bbox":"67.1603227594,27.8939135254,67.8059772818,28.8553957554",
     "geom:latitude":28.406409,
     "geom:longitude":67.524555,
@@ -107,9 +107,10 @@
         "hasc:id":"PK.BA.NS",
         "wd:id":"Q2633556"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319835,
-    "wof:geomhash":"6c55f8ccae58ebced3708a8c3a3a4c1f",
+    "wof:geomhash":"c3df15dabc69b5b991f583e1350d396d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108692221,
-    "wof:lastmodified":1566590167,
+    "wof:lastmodified":1695886672,
     "wof:name":"Jhal Magsi",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/222/3/1108692223.geojson
+++ b/data/110/869/222/3/1108692223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.59486,
-    "geom:area_square_m":6293264963.79027,
+    "geom:area_square_m":6293265527.855614,
     "geom:bbox":"71.65035,30.572658,72.780486,31.766115",
     "geom:latitude":31.174989,
     "geom:longitude":72.177082,
@@ -145,9 +145,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.FS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319836,
-    "wof:geomhash":"d255a6a183fe600ff22c5689ea070477",
+    "wof:geomhash":"82abfeabdc05c402a475353722be8544",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108692223,
-    "wof:lastmodified":1636502017,
+    "wof:lastmodified":1695886042,
     "wof:name":"Jhang",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/222/7/1108692227.geojson
+++ b/data/110/869/222/7/1108692227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.344744,
-    "geom:area_square_m":3581908140.39698,
+    "geom:area_square_m":3581909743.810671,
     "geom:bbox":"72.645486,32.37647,73.798305,33.256189",
     "geom:latitude":32.831235,
     "geom:longitude":73.295876,
@@ -148,9 +148,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.RP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319838,
-    "wof:geomhash":"227e3fdc5a86e3f0d8a0c06795796c29",
+    "wof:geomhash":"2bc89ee595b90e22d6d15416b5e4ce1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108692227,
-    "wof:lastmodified":1636502017,
+    "wof:lastmodified":1695886042,
     "wof:name":"Jhelum",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/222/9/1108692229.geojson
+++ b/data/110/869/222/9/1108692229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.490335,
-    "geom:area_square_m":5285047308.03251,
+    "geom:area_square_m":5285045036.742404,
     "geom:bbox":"67.117004,28.702333,67.987739,29.983358",
     "geom:latitude":29.344401,
     "geom:longitude":67.526604,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319839,
-    "wof:geomhash":"2d5ddb29c2f450b7ce7ff09295f2853c",
+    "wof:geomhash":"3d341ecd2657e94480587baa3b0a7a2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692229,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886156,
     "wof:name":"Kachhi",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/223/1/1108692231.geojson
+++ b/data/110/869/223/1/1108692231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.274149,
-    "geom:area_square_m":13793440693.252787,
+    "geom:area_square_m":13793440693.252542,
     "geom:bbox":"65.8266561718,27.9262170464,67.4662436036,29.6463105536",
     "geom:latitude":28.894294,
     "geom:longitude":66.582684,
@@ -118,9 +118,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q611142"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319841,
-    "wof:geomhash":"f6cf781d49a55655f1441e0a687cf15a",
+    "wof:geomhash":"3b95e0a0e4fe9af0c3fe92b3f4f10d27",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108692231,
-    "wof:lastmodified":1566590163,
+    "wof:lastmodified":1695886670,
     "wof:name":"Kalat",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/223/3/1108692233.geojson
+++ b/data/110/869/223/3/1108692233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330704,
-    "geom:area_square_m":3703795368.770876,
+    "geom:area_square_m":3703795368.77089,
     "geom:bbox":"66.652885437,24.759555817,67.5849169905,25.6510581344",
     "geom:latitude":25.074963,
     "geom:longitude":67.200156,
@@ -491,12 +491,13 @@
     "wof:concordances":{
         "hasc:id":"PK.SD.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421191101
     ],
     "wof:country":"PK",
     "wof:created":1474319842,
-    "wof:geomhash":"13421a973a125d9fcb8d8524ab9a76db",
+    "wof:geomhash":"e3b606152384968b42dfe3e03d7e7d71",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -506,7 +507,7 @@
         }
     ],
     "wof:id":1108692233,
-    "wof:lastmodified":1578081708,
+    "wof:lastmodified":1695886279,
     "wof:name":"Karachi",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/223/5/1108692235.geojson
+++ b/data/110/869/223/5/1108692235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254622,
-    "geom:area_square_m":2636352696.134682,
+    "geom:area_square_m":2636353573.208987,
     "geom:bbox":"70.760202,32.802365,71.471097,33.379649",
     "geom:latitude":33.13864,
     "geom:longitude":71.110328,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319843,
-    "wof:geomhash":"6f443e52c4370265ff33398ac99a4040",
+    "wof:geomhash":"ac37994767de66128e0cbd93f2594a39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108692235,
-    "wof:lastmodified":1627522512,
+    "wof:lastmodified":1695886155,
     "wof:name":"Karak",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/223/7/1108692237.geojson
+++ b/data/110/869/223/7/1108692237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242496,
-    "geom:area_square_m":2640480591.840694,
+    "geom:area_square_m":2640480057.356478,
     "geom:bbox":"68.902256,27.978562,69.842361,28.513676",
     "geom:latitude":28.285111,
     "geom:longitude":69.254644,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.SD.LK",
         "wd:id":"Q32852"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319845,
-    "wof:geomhash":"9b939c78f12817931becf13a148e5775",
+    "wof:geomhash":"a7f733299e5d3923253e4d46366943c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692237,
-    "wof:lastmodified":1690854190,
+    "wof:lastmodified":1695886671,
     "wof:name":"Kashmore",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/223/9/1108692239.geojson
+++ b/data/110/869/223/9/1108692239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368986,
-    "geom:area_square_m":3908785893.610275,
+    "geom:area_square_m":3908785868.626059,
     "geom:bbox":"73.658622,30.648216,74.702351,31.362947",
     "geom:latitude":31.051136,
     "geom:longitude":74.153258,
@@ -154,9 +154,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.LH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319846,
-    "wof:geomhash":"3e9492e0de3ed300c8593140ffa14735",
+    "wof:geomhash":"23befdc6ce399ce6f11b4cb5becd8a15",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108692239,
-    "wof:lastmodified":1636502017,
+    "wof:lastmodified":1695886042,
     "wof:name":"Kasur",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/224/1/1108692241.geojson
+++ b/data/110/869/224/1/1108692241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.17272,
-    "geom:area_square_m":24147245515.399876,
+    "geom:area_square_m":24147244355.196503,
     "geom:bbox":"61.725189,25.361311,64.514561,26.651003",
     "geom:latitude":25.997952,
     "geom:longitude":63.069743,
@@ -125,9 +125,10 @@
         "hasc:id":"PK.BA.MR",
         "wd:id":"Q276716"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319848,
-    "wof:geomhash":"ea13b51d3b7c6cf817f36764d1c72b5d",
+    "wof:geomhash":"9eb2e2995f042e064ee0ab0c56fcf611",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108692241,
-    "wof:lastmodified":1690854191,
+    "wof:lastmodified":1695886671,
     "wof:name":"Kech",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/224/5/1108692245.geojson
+++ b/data/110/869/224/5/1108692245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.44783,
-    "geom:area_square_m":15975314372.732918,
+    "geom:area_square_m":15975312951.948614,
     "geom:bbox":"68.179658,26.132424,70.185623,27.748997",
     "geom:latitude":26.828504,
     "geom:longitude":69.079583,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.SD.SU",
         "wd:id":"Q2512083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319849,
-    "wof:geomhash":"b60f514c2e79b6fc333b92e8720373f4",
+    "wof:geomhash":"082689e79d639d53d3e0854bbdd72961",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692245,
-    "wof:lastmodified":1690854191,
+    "wof:lastmodified":1695886671,
     "wof:name":"Khairpur",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/224/7/1108692247.geojson
+++ b/data/110/869/224/7/1108692247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.406993,
-    "geom:area_square_m":4342012689.292606,
+    "geom:area_square_m":4342012689.292889,
     "geom:bbox":"71.5520602928,29.8796714504,72.4990470088,30.7361185972",
     "geom:latitude":30.368664,
     "geom:longitude":72.021989,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319851,
-    "wof:geomhash":"27185bd6414c8a4fef89171bcee7bd8b",
+    "wof:geomhash":"1661f3bb4d2f2ba1a1ea75f83d3504c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108692247,
-    "wof:lastmodified":1566590164,
+    "wof:lastmodified":1695886671,
     "wof:name":"Khanewal",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/224/9/1108692249.geojson
+++ b/data/110/869/224/9/1108692249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.995022,
-    "geom:area_square_m":10800700881.149551,
+    "geom:area_square_m":10800701848.673851,
     "geom:bbox":"64.736421,28.013586,66.168018,29.344451",
     "geom:latitude":28.615166,
     "geom:longitude":65.465666,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q537334"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319852,
-    "wof:geomhash":"6c85aac3e9a21ee27c2e2135a4c75b29",
+    "wof:geomhash":"4c115d7a50dacf6a5eddaff175eee99d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692249,
-    "wof:lastmodified":1690854191,
+    "wof:lastmodified":1695886671,
     "wof:name":"Kharan",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/225/1/1108692251.geojson
+++ b/data/110/869/225/1/1108692251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.64232,
-    "geom:area_square_m":6721488937.601013,
+    "geom:area_square_m":6721488937.600478,
     "geom:bbox":"71.623985,31.5241864077,72.670416378,32.7193654998",
     "geom:latitude":32.189699,
     "geom:longitude":72.104316,
@@ -85,9 +85,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319854,
-    "wof:geomhash":"65b6aa57ebdfab8d1d8c3e511d4eeb6c",
+    "wof:geomhash":"9baa0795e2659ca6cc6710fc83d25ad4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692251,
-    "wof:lastmodified":1566590167,
+    "wof:lastmodified":1695886672,
     "wof:name":"Khushab",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/225/3/1108692253.geojson
+++ b/data/110/869/225/3/1108692253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.835023,
-    "geom:area_square_m":31102163977.945469,
+    "geom:area_square_m":31102165140.666302,
     "geom:bbox":"65.581677,25.745782,67.400164,28.878489",
     "geom:latitude":27.465818,
     "geom:longitude":66.645386,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q2642523"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319855,
-    "wof:geomhash":"4153e8e7025c8323a00abb31fdf05758",
+    "wof:geomhash":"e672513fea5f89d60427b2b0384b7e62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692253,
-    "wof:lastmodified":1690854193,
+    "wof:lastmodified":1695886672,
     "wof:name":"Khuzdar",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/225/5/1108692255.geojson
+++ b/data/110/869/225/5/1108692255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.267227,
-    "geom:area_square_m":2740805978.999104,
+    "geom:area_square_m":2740805247.446613,
     "geom:bbox":"70.439407,33.739687,71.51507,34.347499",
     "geom:latitude":33.956312,
     "geom:longitude":71.063439,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319857,
-    "wof:geomhash":"d9729d802e3dc9df4d1a93347bd68ca4",
+    "wof:geomhash":"0da7698412633dfa2fe73709ccf6af69",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108692255,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886156,
     "wof:name":"Khyber",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/225/7/1108692257.geojson
+++ b/data/110/869/225/7/1108692257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.542303,
-    "geom:area_square_m":5763947473.449601,
+    "geom:area_square_m":5763947317.385473,
     "geom:bbox":"66.248853,30.070538,67.270067,31.311869",
     "geom:latitude":30.72899,
     "geom:longitude":66.68627,
@@ -119,9 +119,10 @@
         "hasc:id":"PK.BA.QE",
         "wd:id":"Q100106"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319858,
-    "wof:geomhash":"7bd353895bf0df21b7ed15ce7d7d91af",
+    "wof:geomhash":"8b0641cfaac1c5e2d43473ab91913774",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108692257,
-    "wof:lastmodified":1690854193,
+    "wof:lastmodified":1695886671,
     "wof:name":"Killa Abdullah",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/225/9/1108692259.geojson
+++ b/data/110/869/225/9/1108692259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.170119,
-    "geom:area_square_m":12406651924.863358,
+    "geom:area_square_m":12406653698.838121,
     "geom:bbox":"67.440046,30.504046,69.382348,31.588357",
     "geom:latitude":30.964463,
     "geom:longitude":68.322495,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.ZH",
         "wd:id":"Q153340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319860,
-    "wof:geomhash":"fdd8fd224da7d80645f9581cfc22ef8b",
+    "wof:geomhash":"752f384d801fe90c164427ec7c72c7d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692259,
-    "wof:lastmodified":1690854192,
+    "wof:lastmodified":1695886672,
     "wof:name":"Killa Saifullah",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/226/3/1108692263.geojson
+++ b/data/110/869/226/3/1108692263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287413,
-    "geom:area_square_m":2965004688.069586,
+    "geom:area_square_m":2965003677.525873,
     "geom:bbox":"71.063773,33.055388,72.028582,33.762534",
     "geom:latitude":33.457486,
     "geom:longitude":71.537403,
@@ -121,9 +121,10 @@
         "hasc:id":"PK.NW.KH",
         "wd:id":"Q1250340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319861,
-    "wof:geomhash":"fc1198a286fcbc11d87515d77a874c06",
+    "wof:geomhash":"f69a022b43f6e1543fe43bd94bbf4b51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692263,
-    "wof:lastmodified":1690854185,
+    "wof:lastmodified":1695886041,
     "wof:name":"Kohat",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/226/5/1108692265.geojson
+++ b/data/110/869/226/5/1108692265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.761148,
-    "geom:area_square_m":7678403965.796234,
+    "geom:area_square_m":7678403779.263126,
     "geom:bbox":"72.692078,34.898331,73.958324,35.885288",
     "geom:latitude":35.329575,
     "geom:longitude":73.229935,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.NW.HZ",
         "wd:id":"Q728803"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319863,
-    "wof:geomhash":"fc90a9b138e44794e3142db2ffbe1bf8",
+    "wof:geomhash":"388bd6df7ea110ab4e68a969d9c915b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692265,
-    "wof:lastmodified":1690854185,
+    "wof:lastmodified":1695886668,
     "wof:name":"Kohistan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/226/7/1108692267.geojson
+++ b/data/110/869/226/7/1108692267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.729439,
-    "geom:area_square_m":7843024703.71368,
+    "geom:area_square_m":7843024703.713616,
     "geom:bbox":"68.1098552709,29.2180681946,69.6468011299,30.107640971",
     "geom:latitude":29.593075,
     "geom:longitude":68.85613,
@@ -110,9 +110,10 @@
         "hasc:id":"PK.BA.SI",
         "wd:id":"Q2315604"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319864,
-    "wof:geomhash":"f61ad1a1b978e3587d66407972fb002b",
+    "wof:geomhash":"49d45720cf60ec6efb828f9a78056440",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108692267,
-    "wof:lastmodified":1566590154,
+    "wof:lastmodified":1695886668,
     "wof:name":"Kohlu",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/226/9/1108692269.geojson
+++ b/data/110/869/226/9/1108692269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15399,
-    "geom:area_square_m":1588749627.456322,
+    "geom:area_square_m":1588749414.749357,
     "geom:bbox":"73.573284,33.221831,74.192525,33.686417",
     "geom:latitude":33.448696,
     "geom:longitude":73.911997,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319865,
-    "wof:geomhash":"398b3c3fcac072b49b865a827bfa3e29",
+    "wof:geomhash":"c6ae09068785c65d5d1125aca0ceae46",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692269,
-    "wof:lastmodified":1627522513,
+    "wof:lastmodified":1695886156,
     "wof:name":"Kotli",
     "wof:parent_id":85675735,
     "wof:placetype":"county",

--- a/data/110/869/227/1/1108692271.geojson
+++ b/data/110/869/227/1/1108692271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329236,
-    "geom:area_square_m":3386536903.723159,
+    "geom:area_square_m":3386536328.022804,
     "geom:bbox":"69.855755,33.333416,70.755198,34.04779",
     "geom:latitude":33.709852,
     "geom:longitude":70.32406,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319867,
-    "wof:geomhash":"add45b61a09ecd34f0f5cff1bffd106d",
+    "wof:geomhash":"37a882b649fefe3a8ce40a3d696fe24b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108692271,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886156,
     "wof:name":"Kurram",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/227/3/1108692273.geojson
+++ b/data/110/869/227/3/1108692273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158818,
-    "geom:area_square_m":1675136387.852549,
+    "geom:area_square_m":1675136608.933746,
     "geom:bbox":"73.996014,31.255024,74.654623,31.711712",
     "geom:latitude":31.460256,
     "geom:longitude":74.357056,
@@ -127,9 +127,10 @@
         "hasc:id":"PK.PB.LH",
         "wd:id":"Q2315527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319869,
-    "wof:geomhash":"a16b3a3a82f9d1eeb59976a9380b6b0d",
+    "wof:geomhash":"54d45f19fc43baedb1052bc3545ec251",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692273,
-    "wof:lastmodified":1690854182,
+    "wof:lastmodified":1695886157,
     "wof:name":"Lahore",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/227/5/1108692275.geojson
+++ b/data/110/869/227/5/1108692275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301092,
-    "geom:area_square_m":3136492355.789388,
+    "geom:area_square_m":3136492602.14339,
     "geom:bbox":"70.400974,32.260319,71.234601,32.871363",
     "geom:latitude":32.600077,
     "geom:longitude":70.83065,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.NW.BN",
         "wd:id":"Q2039074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319870,
-    "wof:geomhash":"0839bdd6ddfb5e7e202a4cd4bb934961",
+    "wof:geomhash":"2b5f3c98e6e360c6d58708ecd8f7838f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692275,
-    "wof:lastmodified":1690854182,
+    "wof:lastmodified":1695886667,
     "wof:name":"Lakki Marwat",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/227/7/1108692277.geojson
+++ b/data/110/869/227/7/1108692277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176262,
-    "geom:area_square_m":1932759098.449217,
+    "geom:area_square_m":1932758427.052964,
     "geom:bbox":"67.927767,27.126977,68.485333,27.947649",
     "geom:latitude":27.527193,
     "geom:longitude":68.191135,
@@ -136,9 +136,10 @@
         "hasc:id":"PK.SD.LK",
         "wd:id":"Q2281289"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319871,
-    "wof:geomhash":"7a1ceb1ed73547783682acf7a90c92eb",
+    "wof:geomhash":"7ed8082549aa667078d1190b029427d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108692277,
-    "wof:lastmodified":1690854182,
+    "wof:lastmodified":1695886040,
     "wof:name":"Larkana",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/228/1/1108692281.geojson
+++ b/data/110/869/228/1/1108692281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.285315,
-    "geom:area_square_m":14308851074.92326,
+    "geom:area_square_m":14308850675.928049,
     "geom:bbox":"65.189349,24.89271,67.434555,26.65411",
     "geom:latitude":25.798091,
     "geom:longitude":66.643821,
@@ -125,9 +125,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q44942"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319873,
-    "wof:geomhash":"5a86fa350ed652de400b1e242fc406db",
+    "wof:geomhash":"07702cabb4e7ed9693c23b914dc883c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108692281,
-    "wof:lastmodified":1690854187,
+    "wof:lastmodified":1695886668,
     "wof:name":"Las Bela",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/228/3/1108692283.geojson
+++ b/data/110/869/228/3/1108692283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.604626,
-    "geom:area_square_m":6410420029.258242,
+    "geom:area_square_m":6410420029.25851,
     "geom:bbox":"70.7188217224,30.565883638,71.8589265922,31.3817237292",
     "geom:latitude":30.970336,
     "geom:longitude":71.249773,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319874,
-    "wof:geomhash":"feffd0a97cf51a6b657f2c36c62ec210",
+    "wof:geomhash":"c27f88526bbaa0bcf849a4ac4488faad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692283,
-    "wof:lastmodified":1566590157,
+    "wof:lastmodified":1695886668,
     "wof:name":"Layyah",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/228/5/1108692285.geojson
+++ b/data/110/869/228/5/1108692285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307012,
-    "geom:area_square_m":3320070563.655583,
+    "geom:area_square_m":3320069345.804204,
     "geom:bbox":"67.645913,28.602109,68.460729,29.376789",
     "geom:latitude":29.00645,
     "geom:longitude":68.008578,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319876,
-    "wof:geomhash":"a847d74e0d92b055d55b565f226244a6",
+    "wof:geomhash":"666fee125ae5f5a23a525f5a92589ba7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692285,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886157,
     "wof:name":"Lehri",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/228/7/1108692287.geojson
+++ b/data/110/869/228/7/1108692287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.244921,
-    "geom:area_square_m":2631343633.325867,
+    "geom:area_square_m":2631342934.39913,
     "geom:bbox":"71.35454,29.358707,72.107135,29.96122",
     "geom:latitude":29.67311,
     "geom:longitude":71.688506,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319877,
-    "wof:geomhash":"8ec84828958be1a5dba895ab9ed9841b",
+    "wof:geomhash":"9d02c92fb1c591eceae308421139b15b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692287,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886157,
     "wof:name":"Lodhran",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/228/9/1108692289.geojson
+++ b/data/110/869/228/9/1108692289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158051,
-    "geom:area_square_m":1603902042.772941,
+    "geom:area_square_m":1603901966.418835,
     "geom:bbox":"71.50233,34.623017,72.185737,35.074886",
     "geom:latitude":34.846019,
     "geom:longitude":71.843607,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319885,
-    "wof:geomhash":"640a58fa5cb8e0b8a0dc460d8dc69c19",
+    "wof:geomhash":"af899abf0817b9a385f71c2e0bc25a6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692289,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886157,
     "wof:name":"Lower Dir",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/229/1/1108692291.geojson
+++ b/data/110/869/229/1/1108692291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095017,
-    "geom:area_square_m":967815906.94118,
+    "geom:area_square_m":967815590.62839,
     "geom:bbox":"71.637336,34.363887,72.231024,34.660314",
     "geom:latitude":34.538892,
     "geom:longitude":71.893434,
@@ -123,9 +123,10 @@
         "hasc:id":"PK.NW.MD",
         "wd:id":"Q3240564"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319886,
-    "wof:geomhash":"40922dc847b8741070c6864a487f7852",
+    "wof:geomhash":"2a497eb5769ee76ae5da0ebc106523d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108692291,
-    "wof:lastmodified":1690854181,
+    "wof:lastmodified":1695886667,
     "wof:name":"Malakand PA",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/229/3/1108692293.geojson
+++ b/data/110/869/229/3/1108692293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266189,
-    "geom:area_square_m":2777978409.062636,
+    "geom:area_square_m":2777978409.062791,
     "geom:bbox":"73.0518620714,32.1061287735,73.8949463525,32.7453219167",
     "geom:latitude":32.435656,
     "geom:longitude":73.452933,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.PB.GW",
         "wd:id":"Q2419031"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319888,
-    "wof:geomhash":"e720e00fa695636f11a684bd39a51ee0",
+    "wof:geomhash":"4a72c85cd6747f3bd931003b8f0ff0c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692293,
-    "wof:lastmodified":1566590149,
+    "wof:lastmodified":1695886667,
     "wof:name":"Mandi Bahauddin",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/229/5/1108692295.geojson
+++ b/data/110/869/229/5/1108692295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.424391,
-    "geom:area_square_m":4316294212.710201,
+    "geom:area_square_m":4316294243.265347,
     "geom:bbox":"72.796566,34.199896,74.135484,35.184531",
     "geom:latitude":34.661978,
     "geom:longitude":73.437464,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.HZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319889,
-    "wof:geomhash":"5ff40fac300ae4455dbcd0a7c56c46d6",
+    "wof:geomhash":"44a45625f991bbd3346947b20842261b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692295,
-    "wof:lastmodified":1636502014,
+    "wof:lastmodified":1695886040,
     "wof:name":"Mansehra",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/229/9/1108692299.geojson
+++ b/data/110/869/229/9/1108692299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160969,
-    "geom:area_square_m":1643997201.399685,
+    "geom:area_square_m":1643996376.944756,
     "geom:bbox":"71.81465,34.063844,72.439403,34.543589",
     "geom:latitude":34.314076,
     "geom:longitude":72.101393,
@@ -118,9 +118,10 @@
         "hasc:id":"PK.NW.MA",
         "wd:id":"Q2379056"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319891,
-    "wof:geomhash":"b2df7da7bfb9de04af1798d2b5b8ddd3",
+    "wof:geomhash":"8f64669b6a30e8eedd09346667a590cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108692299,
-    "wof:lastmodified":1690854181,
+    "wof:lastmodified":1695886041,
     "wof:name":"Mardan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/230/1/1108692301.geojson
+++ b/data/110/869/230/1/1108692301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.538353,
-    "geom:area_square_m":5777700333.12101,
+    "geom:area_square_m":5777701011.745621,
     "geom:bbox":"66.181995,29.333183,67.440583,30.247328",
     "geom:latitude":29.779861,
     "geom:longitude":66.828837,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q1026625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319892,
-    "wof:geomhash":"b4ab5412a08e74d1730ae8e3ce571381",
+    "wof:geomhash":"80207ee6ed4efd3cad9f91f24d7be53e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692301,
-    "wof:lastmodified":1690854198,
+    "wof:lastmodified":1695886674,
     "wof:name":"Mastung",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/230/3/1108692303.geojson
+++ b/data/110/869/230/3/1108692303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136525,
-    "geom:area_square_m":1520427599.491239,
+    "geom:area_square_m":1520427706.242849,
     "geom:bbox":"68.227135,25.438605,68.679558,26.093893",
     "geom:latitude":25.756381,
     "geom:longitude":68.454825,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2419054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319894,
-    "wof:geomhash":"0b600436f1557766355dea3b8dba3432",
+    "wof:geomhash":"04d1a37ae33951f7a8b8c7b269c399ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692303,
-    "wof:lastmodified":1690854198,
+    "wof:lastmodified":1695886674,
     "wof:name":"Matiari",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/230/5/1108692305.geojson
+++ b/data/110/869/230/5/1108692305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.576891,
-    "geom:area_square_m":6004922278.671858,
+    "geom:area_square_m":6004922278.671585,
     "geom:bbox":"71.1032891551,32.1645759345,71.9739382562,33.2424135001",
     "geom:latitude":32.667756,
     "geom:longitude":71.527506,
@@ -103,9 +103,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319895,
-    "wof:geomhash":"60bb2fe19fb8b9ace6e8dcc25b709627",
+    "wof:geomhash":"c1caab983b01df09a170954e73d2760e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692305,
-    "wof:lastmodified":1566590174,
+    "wof:lastmodified":1695886674,
     "wof:name":"Mianwali",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/230/7/1108692307.geojson
+++ b/data/110/869/230/7/1108692307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264996,
-    "geom:area_square_m":2963023777.574331,
+    "geom:area_square_m":2963023918.36752,
     "geom:bbox":"68.871044,24.799164,69.524389,25.754982",
     "geom:latitude":25.274925,
     "geom:longitude":69.164918,
@@ -115,9 +115,10 @@
         "hasc:id":"PK.SD.MK",
         "wd:id":"Q82253"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319896,
-    "wof:geomhash":"6a74798c6c3f0ccb759192e4df07ab0b",
+    "wof:geomhash":"d6288d8d82b70660e5f4187efda48826",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108692307,
-    "wof:lastmodified":1690854197,
+    "wof:lastmodified":1695886674,
     "wof:name":"Mirpur Khas",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/230/9/1108692309.geojson
+++ b/data/110/869/230/9/1108692309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08471,
-    "geom:area_square_m":876126094.494274,
+    "geom:area_square_m":876127108.277258,
     "geom:bbox":"73.546068,33.008788,73.920139,33.468025",
     "geom:latitude":33.234783,
     "geom:longitude":73.735048,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319898,
-    "wof:geomhash":"bfd2bf243243fa27c3e281ff6c77ef7b",
+    "wof:geomhash":"819e9f253e09585c60f6b6d961a04bd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108692309,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886157,
     "wof:name":"Mirpur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/869/231/1/1108692311.geojson
+++ b/data/110/869/231/1/1108692311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217226,
-    "geom:area_square_m":2214589603.302952,
+    "geom:area_square_m":2214589694.106114,
     "geom:bbox":"71.00421,34.134703,71.723451,34.730653",
     "geom:latitude":34.464127,
     "geom:longitude":71.343161,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319899,
-    "wof:geomhash":"fca10e0c3de633c6106b0b5bb793e14d",
+    "wof:geomhash":"d1c27c6768668dc9b49652d5bcb44521",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108692311,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886157,
     "wof:name":"Mohmand",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/231/3/1108692313.geojson
+++ b/data/110/869/231/3/1108692313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.341695,
-    "geom:area_square_m":3661307511.651862,
+    "geom:area_square_m":3661307777.44762,
     "geom:bbox":"70.997077,29.415409,71.832071,30.448809",
     "geom:latitude":29.938068,
     "geom:longitude":71.407437,
@@ -133,9 +133,10 @@
         "hasc:id":"PK.PB.MT",
         "wd:id":"Q2281168"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319901,
-    "wof:geomhash":"559f6d0014b5fb43dda379526162702a",
+    "wof:geomhash":"fa768a4854fd164b383aa7292a55c55a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108692313,
-    "wof:lastmodified":1690854195,
+    "wof:lastmodified":1695886673,
     "wof:name":"Multan",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/231/7/1108692317.geojson
+++ b/data/110/869/231/7/1108692317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.564982,
-    "geom:area_square_m":5996370399.468554,
+    "geom:area_square_m":5996370399.468801,
     "geom:bbox":"69.4667097955,30.2881485919,70.3061324214,31.506391108",
     "geom:latitude":30.86959,
     "geom:longitude":69.918375,
@@ -98,9 +98,10 @@
         "hasc:id":"PK.BA.ZH",
         "wd:id":"Q2315489"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319902,
-    "wof:geomhash":"0f3adb9514739ae9669561276e7413a4",
+    "wof:geomhash":"13b550f0eef9bcf94966cc15ab62aac9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108692317,
-    "wof:lastmodified":1566590170,
+    "wof:lastmodified":1695886673,
     "wof:name":"Musakhel",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/231/9/1108692319.geojson
+++ b/data/110/869/231/9/1108692319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.19759,
-    "geom:area_square_m":2018477608.537294,
+    "geom:area_square_m":2018477608.537417,
     "geom:bbox":"73.3991673613,33.9961581027,74.01124,34.5889966653",
     "geom:latitude":34.294858,
     "geom:longitude":73.678054,
@@ -164,9 +164,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319904,
-    "wof:geomhash":"4cb58c4324e48a9a9e414b02bc88a6f6",
+    "wof:geomhash":"6417a02c1b8d2d67c5706bac1790b7a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":1108692319,
-    "wof:lastmodified":1566590170,
+    "wof:lastmodified":1695886673,
     "wof:name":"Muzaffarabad",
     "wof:parent_id":85675735,
     "wof:placetype":"county",

--- a/data/110/869/232/1/1108692321.geojson
+++ b/data/110/869/232/1/1108692321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.716191,
-    "geom:area_square_m":7665140931.809031,
+    "geom:area_square_m":7665140931.808607,
     "geom:bbox":"70.5255372045,29.0085398276,71.7312608619,30.7767605661",
     "geom:latitude":30.051754,
     "geom:longitude":71.040432,
@@ -115,9 +115,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319905,
-    "wof:geomhash":"45da1d475a6c69385bed83ccc77b4df3",
+    "wof:geomhash":"8d545e3553448d2b08b3e24ad74cb390",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108692321,
-    "wof:lastmodified":1566590158,
+    "wof:lastmodified":1695886669,
     "wof:name":"Muzaffargarh",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/232/3/1108692323.geojson
+++ b/data/110/869/232/3/1108692323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263271,
-    "geom:area_square_m":2775686027.625402,
+    "geom:area_square_m":2775686027.625355,
     "geom:bbox":"73.2951344485,31.036545715,74.0366566364,31.9162896686",
     "geom:latitude":31.499354,
     "geom:longitude":73.675827,
@@ -103,9 +103,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.LH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319907,
-    "wof:geomhash":"9740502d9403a13b57865ab7627feda9",
+    "wof:geomhash":"7236af7a4b9476127a95d4e0477748d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692323,
-    "wof:lastmodified":1566590158,
+    "wof:lastmodified":1695886669,
     "wof:name":"Nankana Sahib",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/232/5/1108692325.geojson
+++ b/data/110/869/232/5/1108692325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.220394,
-    "geom:area_square_m":2305828628.899513,
+    "geom:area_square_m":2305828001.830968,
     "geom:bbox":"74.593845,31.921202,75.3814,32.49731",
     "geom:latitude":32.20906,
     "geom:longitude":74.996196,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.PB.GW",
         "wd:id":"Q2419016"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319908,
-    "wof:geomhash":"c5b2a8ba77e3588ed66f0ad8597630e2",
+    "wof:geomhash":"11287de1897c56ee1fcdee455533edf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692325,
-    "wof:lastmodified":1690854188,
+    "wof:lastmodified":1695886669,
     "wof:name":"Narowal",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/232/7/1108692327.geojson
+++ b/data/110/869/232/7/1108692327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298732,
-    "geom:area_square_m":3243363143.037395,
+    "geom:area_square_m":3243362807.780372,
     "geom:bbox":"67.729467,28.184992,68.445099,29.04991",
     "geom:latitude":28.592997,
     "geom:longitude":68.101328,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319910,
-    "wof:geomhash":"d70b1fbf5ef575a5400513450a660e1a",
+    "wof:geomhash":"7e33d914748764e101b3e453666166df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108692327,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886157,
     "wof:name":"Nasirabad",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/232/9/1108692329.geojson
+++ b/data/110/869/232/9/1108692329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273017,
-    "geom:area_square_m":3011083983.615448,
+    "geom:area_square_m":3011084065.671942,
     "geom:bbox":"67.802003,26.549212,68.44787,27.237249",
     "geom:latitude":26.882469,
     "geom:longitude":68.123783,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.SD.SU",
         "wd:id":"Q63711"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319911,
-    "wof:geomhash":"d1363c166fc3c7325b0df38fafbe5290",
+    "wof:geomhash":"c1cb0f389f5f3b849ebba69268910574",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692329,
-    "wof:lastmodified":1690854187,
+    "wof:lastmodified":1695886668,
     "wof:name":"Naushahro Feroze",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/233/1/1108692331.geojson
+++ b/data/110/869/233/1/1108692331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.308381,
-    "geom:area_square_m":3130989605.87854,
+    "geom:area_square_m":3130989105.871165,
     "geom:bbox":"73.629711,34.381103,74.814917,35.131646",
     "geom:latitude":34.805328,
     "geom:longitude":74.192346,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319912,
-    "wof:geomhash":"6c2089bf8d57103f91708bbea46ffad6",
+    "wof:geomhash":"e63304799edf700478008387ff216b22",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108692331,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886158,
     "wof:name":"Neelum",
     "wof:parent_id":85675735,
     "wof:placetype":"county",

--- a/data/110/869/233/5/1108692335.geojson
+++ b/data/110/869/233/5/1108692335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.16893,
-    "geom:area_square_m":1733186242.591959,
+    "geom:area_square_m":1733186787.479147,
     "geom:bbox":"71.69281,33.689616,72.25775,34.141438",
     "geom:latitude":33.928472,
     "geom:longitude":71.982931,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319915,
-    "wof:geomhash":"8d2ca9492db8903939e49b805e8ed7c7",
+    "wof:geomhash":"7d268a9f1c7706a83cd77d9aa667487b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108692335,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886158,
     "wof:name":"Nowshera",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/233/7/1108692337.geojson
+++ b/data/110/869/233/7/1108692337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.539281,
-    "geom:area_square_m":5806334416.57556,
+    "geom:area_square_m":5806334000.632429,
     "geom:bbox":"65.13581,29.011067,66.310656,29.854655",
     "geom:latitude":29.454654,
     "geom:longitude":65.769774,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.QE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319917,
-    "wof:geomhash":"d637d1b2b425142eb44cd0bd4f6fbeca",
+    "wof:geomhash":"a75576d6a2c184100a5aa05327eb44a7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692337,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886158,
     "wof:name":"Nushki",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/233/9/1108692339.geojson
+++ b/data/110/869/233/9/1108692339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.415706,
-    "geom:area_square_m":4419407372.245184,
+    "geom:area_square_m":4419406953.154024,
     "geom:bbox":"73.270962,30.260463,74.163183,31.161088",
     "geom:latitude":30.709825,
     "geom:longitude":73.688573,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.LH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319918,
-    "wof:geomhash":"c24c5539b1371f7bf338a366e8dd00f4",
+    "wof:geomhash":"e426fa81f08d3a4c40381c0ee58c8642",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692339,
-    "wof:lastmodified":1636502016,
+    "wof:lastmodified":1695886042,
     "wof:name":"Okara",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/234/1/1108692341.geojson
+++ b/data/110/869/234/1/1108692341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130573,
-    "geom:area_square_m":1343279775.120602,
+    "geom:area_square_m":1343281149.544392,
     "geom:bbox":"70.592503,33.552351,71.413358,33.847273",
     "geom:latitude":33.697406,
     "geom:longitude":70.990505,
@@ -62,9 +62,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319919,
-    "wof:geomhash":"72fc0553cc298d29fb74b30d60a0e175",
+    "wof:geomhash":"876150d3b4de676e24c90e214a526775",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108692341,
-    "wof:lastmodified":1627522514,
+    "wof:lastmodified":1695886158,
     "wof:name":"Orakzai",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/234/3/1108692343.geojson
+++ b/data/110/869/234/3/1108692343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273262,
-    "geom:area_square_m":2917286426.26791,
+    "geom:area_square_m":2917286426.26796,
     "geom:bbox":"72.8573400589,29.9439120571,73.6592961696,30.6075556579",
     "geom:latitude":30.302337,
     "geom:longitude":73.253225,
@@ -103,9 +103,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319921,
-    "wof:geomhash":"790782d19b5f1a64d5e77b1e52f54738",
+    "wof:geomhash":"4b8199b3fcf1e42bf2c9c263744c51fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692343,
-    "wof:lastmodified":1566590159,
+    "wof:lastmodified":1695886669,
     "wof:name":"Pakpattan",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/234/5/1108692345.geojson
+++ b/data/110/869/234/5/1108692345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.582911,
-    "geom:area_square_m":17478654808.173611,
+    "geom:area_square_m":17478653686.841347,
     "geom:bbox":"63.078266,26.146976,65.339538,27.290521",
     "geom:latitude":26.746542,
     "geom:longitude":64.15582,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.MR",
         "wd:id":"Q2428944"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319922,
-    "wof:geomhash":"d35a704655be3f06c11dc6e52538b934",
+    "wof:geomhash":"02267cd182eaa61fa1d8d53fdc25a165",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692345,
-    "wof:lastmodified":1690854188,
+    "wof:lastmodified":1695886669,
     "wof:name":"Panjgur",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/234/7/1108692347.geojson
+++ b/data/110/869/234/7/1108692347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124123,
-    "geom:area_square_m":1272818461.177836,
+    "geom:area_square_m":1272818293.981967,
     "geom:bbox":"71.36984,33.714327,71.778897,34.227289",
     "geom:latitude":33.972483,
     "geom:longitude":71.568948,
@@ -124,9 +124,10 @@
         "hasc:id":"PK.NW.PS",
         "wd:id":"Q549467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319924,
-    "wof:geomhash":"b4210e2bb738682f8fccdb877697f0f7",
+    "wof:geomhash":"e98397b8cba9b34ff6ff701f21c3636d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108692347,
-    "wof:lastmodified":1690854188,
+    "wof:lastmodified":1695886669,
     "wof:name":"Peshawar",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/234/9/1108692349.geojson
+++ b/data/110/869/234/9/1108692349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.464083,
-    "geom:area_square_m":4928719717.055924,
+    "geom:area_square_m":4928720097.387972,
     "geom:bbox":"66.771691,30.359483,67.819306,31.232102",
     "geom:latitude":30.807272,
     "geom:longitude":67.253156,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.BA.QE",
         "wd:id":"Q2281172"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319925,
-    "wof:geomhash":"939ccd5e9ccdaf4b84af8531ea19e3f4",
+    "wof:geomhash":"22e2155ec32431a38c5d156d70830e3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692349,
-    "wof:lastmodified":1690854188,
+    "wof:lastmodified":1695886669,
     "wof:name":"Pishin",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/235/3/1108692353.geojson
+++ b/data/110/869/235/3/1108692353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071897,
-    "geom:area_square_m":738601593.157751,
+    "geom:area_square_m":738602161.737534,
     "geom:bbox":"73.536935,33.577205,74.048221,33.978263",
     "geom:latitude":33.818436,
     "geom:longitude":73.832756,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319927,
-    "wof:geomhash":"1dbb587e52ee95900c2fe95e63d98b7a",
+    "wof:geomhash":"2763d7b528e6a6c77f06ddc720c8b29a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108692353,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886158,
     "wof:name":"Poonch",
     "wof:parent_id":85675735,
     "wof:placetype":"county",

--- a/data/110/869/235/5/1108692355.geojson
+++ b/data/110/869/235/5/1108692355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.51212,
-    "geom:area_square_m":5610008895.253748,
+    "geom:area_square_m":5610009616.802987,
     "geom:bbox":"67.149781,27.282898,68.190971,28.00663",
     "geom:latitude":27.635526,
     "geom:longitude":67.704107,
@@ -134,9 +134,10 @@
         "hasc:id":"PK.SD.LK",
         "wd:id":"Q2281289"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319928,
-    "wof:geomhash":"6d85f05e9567ec16ac443f0fe74668ab",
+    "wof:geomhash":"2911cc0a84086548d0492c53a46e6ed2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108692355,
-    "wof:lastmodified":1690854187,
+    "wof:lastmodified":1695886668,
     "wof:name":"Qambar Shahdadkot",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/235/7/1108692357.geojson
+++ b/data/110/869/235/7/1108692357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.191668,
-    "geom:area_square_m":12959572686.060705,
+    "geom:area_square_m":12959574423.896545,
     "geom:bbox":"69.461969,27.705626,71.110554,29.26645",
     "geom:latitude":28.416212,
     "geom:longitude":70.528555,
@@ -138,9 +138,10 @@
         "hasc:id":"PK.PB.BW",
         "wd:id":"Q2281250"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319930,
-    "wof:geomhash":"88edeccfc6c9b3f0e7b84bd8c09c0a4f",
+    "wof:geomhash":"bb61067cd1eaa91eea5ef575948c43c1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108692357,
-    "wof:lastmodified":1690854187,
+    "wof:lastmodified":1695886042,
     "wof:name":"Rahim Yar Khan",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/235/9/1108692359.geojson
+++ b/data/110/869/235/9/1108692359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.16354,
-    "geom:area_square_m":12563696113.255108,
+    "geom:area_square_m":12563696113.255434,
     "geom:bbox":"69.297929513,28.3683145266,70.7274440707,29.9063524842",
     "geom:latitude":29.160011,
     "geom:longitude":70.029842,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319931,
-    "wof:geomhash":"68e24b316996fe9627ef7ebb6d63b332",
+    "wof:geomhash":"5fdc5b21acea92d308d2e785d3d874dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692359,
-    "wof:lastmodified":1566590157,
+    "wof:lastmodified":1695886669,
     "wof:name":"Rajanpur",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/236/1/1108692361.geojson
+++ b/data/110/869/236/1/1108692361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.491809,
-    "geom:area_square_m":5073496163.969473,
+    "geom:area_square_m":5073494536.375854,
     "geom:bbox":"72.632447,33.064717,73.642413,34.016397",
     "geom:latitude":33.458881,
     "geom:longitude":73.200382,
@@ -133,9 +133,10 @@
         "hasc:id":"PK.PB.RP",
         "wd:id":"Q24440"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319933,
-    "wof:geomhash":"c5287f8ff909284c2ceeffe9c84d7b39",
+    "wof:geomhash":"d598b0c1ce7fb5e2fd66b8db546c3970",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108692361,
-    "wof:lastmodified":1690854195,
+    "wof:lastmodified":1695886673,
     "wof:name":"Rawalpindi",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/236/3/1108692363.geojson
+++ b/data/110/869/236/3/1108692363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303517,
-    "geom:area_square_m":3232056100.974247,
+    "geom:area_square_m":3232054712.547966,
     "geom:bbox":"72.393281,30.165903,73.377608,30.933878",
     "geom:latitude":30.550117,
     "geom:longitude":72.899649,
@@ -127,9 +127,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319934,
-    "wof:geomhash":"4d3b2bdfb8bd04165d63be59d9fed372",
+    "wof:geomhash":"72f724293b1e27478d13b5bc441b8298",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692363,
-    "wof:lastmodified":1636502018,
+    "wof:lastmodified":1695886043,
     "wof:name":"Sahiwal",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/236/5/1108692365.geojson
+++ b/data/110/869/236/5/1108692365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.968366,
-    "geom:area_square_m":10766496332.896263,
+    "geom:area_square_m":10766496948.751211,
     "geom:bbox":"68.400438,25.481204,70.217969,26.465382",
     "geom:latitude":25.952326,
     "geom:longitude":69.282933,
@@ -110,9 +110,10 @@
         "hasc:id":"PK.SD.MK",
         "wd:id":"Q1777286"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319936,
-    "wof:geomhash":"eab2a407725f5eda824fa4f70d1becbf",
+    "wof:geomhash":"d9ce38453338d53a5434f47d7ebf574c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108692365,
-    "wof:lastmodified":1690854195,
+    "wof:lastmodified":1695886673,
     "wof:name":"Sanghar",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/236/7/1108692367.geojson
+++ b/data/110/869/236/7/1108692367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.546266,
-    "geom:area_square_m":5722099628.749655,
+    "geom:area_square_m":5722100126.785837,
     "geom:bbox":"72.20953,31.561319,73.279354,32.59713",
     "geom:latitude":32.098492,
     "geom:longitude":72.744025,
@@ -121,9 +121,10 @@
         "hasc:id":"PK.PB.SG",
         "wd:id":"Q2315589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319937,
-    "wof:geomhash":"03b3cdd4b57d59049988a1c0675c6fcc",
+    "wof:geomhash":"37014474fc7eee926e49d34c4712339b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692367,
-    "wof:lastmodified":1636502018,
+    "wof:lastmodified":1695886043,
     "wof:name":"Sargodha",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/237/1/1108692371.geojson
+++ b/data/110/869/237/1/1108692371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404075,
-    "geom:area_square_m":4476632410.044385,
+    "geom:area_square_m":4476631942.005165,
     "geom:bbox":"67.870389,25.982169,68.855382,26.6564",
     "geom:latitude":26.367608,
     "geom:longitude":68.332095,
@@ -117,9 +117,10 @@
         "hasc:id":"PK.SD.SU",
         "wd:id":"Q64170"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319939,
-    "wof:geomhash":"41a5cb471c967b1d845cea7b91194619",
+    "wof:geomhash":"e5f2749f360113d129b9d9366b5ed7cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108692371,
-    "wof:lastmodified":1690854197,
+    "wof:lastmodified":1695886674,
     "wof:name":"Shaheed Benazirabad",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/237/3/1108692373.geojson
+++ b/data/110/869/237/3/1108692373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133452,
-    "geom:area_square_m":1354140353.613657,
+    "geom:area_square_m":1354141053.681809,
     "geom:bbox":"72.527621,34.534985,73.00428,35.17291",
     "geom:latitude":34.853437,
     "geom:longitude":72.732493,
@@ -123,9 +123,10 @@
         "hasc:id":"PK.NW.MD",
         "wd:id":"Q3240564"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319940,
-    "wof:geomhash":"85042255b6d046177720756071e28b14",
+    "wof:geomhash":"2c25fe2948c12f6cdb58775d7529e8c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108692373,
-    "wof:lastmodified":1690854197,
+    "wof:lastmodified":1695886674,
     "wof:name":"Shangla",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/237/5/1108692375.geojson
+++ b/data/110/869/237/5/1108692375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.27141,
-    "geom:area_square_m":2856952437.814075,
+    "geom:area_square_m":2856952581.063394,
     "geom:bbox":"69.521957,31.284206,70.064119,32.108324",
     "geom:latitude":31.647284,
     "geom:longitude":69.771665,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.BA.ZH",
         "wd:id":"Q2281313"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319941,
-    "wof:geomhash":"fb5cbe473e0c0dc916089cfd8e157bb6",
+    "wof:geomhash":"858f95312a7cf44546cbc230f595ce51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692375,
-    "wof:lastmodified":1690854197,
+    "wof:lastmodified":1695886674,
     "wof:name":"Sheerani",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/237/7/1108692377.geojson
+++ b/data/110/869/237/7/1108692377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285375,
-    "geom:area_square_m":3001240341.785217,
+    "geom:area_square_m":3001240341.78549,
     "geom:bbox":"73.6075674386,31.3492639533,74.6868273298,32.0835577056",
     "geom:latitude":31.731672,
     "geom:longitude":74.141006,
@@ -127,9 +127,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.LH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319943,
-    "wof:geomhash":"e16dd2aa880e388e3e03e005c781f314",
+    "wof:geomhash":"fa09513db79457a90b427b0443555b42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692377,
-    "wof:lastmodified":1566590173,
+    "wof:lastmodified":1695886674,
     "wof:name":"Sheikhupura",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/237/9/1108692379.geojson
+++ b/data/110/869/237/9/1108692379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236542,
-    "geom:area_square_m":2583685554.263403,
+    "geom:area_square_m":2583685554.263425,
     "geom:bbox":"68.2273360444,27.6879140402,69.0842538997,28.1792518556",
     "geom:latitude":27.951304,
     "geom:longitude":68.609639,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.SD.LK",
         "wd:id":"Q2315433"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319944,
-    "wof:geomhash":"061b3e3809666399e6691cc0211b0e89",
+    "wof:geomhash":"9a53dc83347415439bfa48cae558a4f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692379,
-    "wof:lastmodified":1566590173,
+    "wof:lastmodified":1695886674,
     "wof:name":"Shikarpur",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/238/1/1108692381.geojson
+++ b/data/110/869/238/1/1108692381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292543,
-    "geom:area_square_m":3053810848.599718,
+    "geom:area_square_m":3053811799.065336,
     "geom:bbox":"74.200184,32.043225,74.94749,32.841919",
     "geom:latitude":32.412039,
     "geom:longitude":74.540415,
@@ -123,9 +123,10 @@
         "hasc:id":"PK.PB.GW",
         "wd:id":"Q2315579"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319946,
-    "wof:geomhash":"f4d9969d9685608565b2b89a55254916",
+    "wof:geomhash":"be77e8884ff1a5e5adc113832015bae8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108692381,
-    "wof:lastmodified":1690854196,
+    "wof:lastmodified":1695886673,
     "wof:name":"Sialkot",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/238/3/1108692383.geojson
+++ b/data/110/869/238/3/1108692383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.463396,
-    "geom:area_square_m":4974249543.461179,
+    "geom:area_square_m":4974250093.203485,
     "geom:bbox":"67.358468,29.309384,68.57237,30.12609",
     "geom:latitude":29.759998,
     "geom:longitude":67.947308,
@@ -124,9 +124,10 @@
         "hasc:id":"PK.BA.SI",
         "wd:id":"Q2483088"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319948,
-    "wof:geomhash":"5398a362c5824b7c57ae78f3541ffcb5",
+    "wof:geomhash":"69d3e5f95ecaa329afb7b36cff5d5201",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108692383,
-    "wof:lastmodified":1690854196,
+    "wof:lastmodified":1695886673,
     "wof:name":"Sibi",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/238/5/1108692385.geojson
+++ b/data/110/869/238/5/1108692385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051841,
-    "geom:area_square_m":563272895.590061,
+    "geom:area_square_m":563273013.648061,
     "geom:bbox":"68.356592,28.422178,68.882827,28.67602",
     "geom:latitude":28.513902,
     "geom:longitude":68.585474,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"PK.BA.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319949,
-    "wof:geomhash":"21f359eec63f1562001d42d5e9c5ba8e",
+    "wof:geomhash":"f2ca8ad9696aac17dec190d50cd04b8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108692385,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886159,
     "wof:name":"Sohbatpur",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/238/9/1108692389.geojson
+++ b/data/110/869/238/9/1108692389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.599191,
-    "geom:area_square_m":6261482814.727801,
+    "geom:area_square_m":6261482814.727078,
     "geom:bbox":"69.2378,31.8147178126,70.4169574838,32.7720368946",
     "geom:latitude":32.316075,
     "geom:longitude":69.750993,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"PK.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319950,
-    "wof:geomhash":"cd7e70b3cc99af63d767831b64ea6541",
+    "wof:geomhash":"b8c752f7a012d3b71224fae510d99716",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108692389,
-    "wof:lastmodified":1566590171,
+    "wof:lastmodified":1695886673,
     "wof:name":"South Waziristan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/239/1/1108692391.geojson
+++ b/data/110/869/239/1/1108692391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059562,
-    "geom:area_square_m":612707271.230491,
+    "geom:area_square_m":612707669.064484,
     "geom:bbox":"73.537983,33.574926,73.957772,33.838361",
     "geom:latitude":33.703354,
     "geom:longitude":73.741911,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"PK.JK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319952,
-    "wof:geomhash":"2eec763cca7227d02fac9ecf6eab223a",
+    "wof:geomhash":"9c944c8b3607321b73bd7c8d9fe81e47",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108692391,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886159,
     "wof:name":"Sudhnoti",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/869/239/3/1108692393.geojson
+++ b/data/110/869/239/3/1108692393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.772948,
-    "geom:area_square_m":8714514715.623924,
+    "geom:area_square_m":8714515713.738644,
     "geom:bbox":"67.461197,23.693722,68.76942,24.989072",
     "geom:latitude":24.245507,
     "geom:longitude":68.151979,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2419234"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319953,
-    "wof:geomhash":"a4431d83107f2f068a3a9a39a2f944e6",
+    "wof:geomhash":"9184ffb8521914f9eb2fcefb95a0d9f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692393,
-    "wof:lastmodified":1690854196,
+    "wof:lastmodified":1695886673,
     "wof:name":"Sujawal",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/239/5/1108692395.geojson
+++ b/data/110/869/239/5/1108692395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.471228,
-    "geom:area_square_m":5168294445.907412,
+    "geom:area_square_m":5168294764.487867,
     "geom:bbox":"68.593926,27.061766,69.768752,28.041557",
     "geom:latitude":27.502624,
     "geom:longitude":69.169451,
@@ -115,9 +115,10 @@
         "hasc:id":"PK.SD.SU",
         "wd:id":"Q32854"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319955,
-    "wof:geomhash":"ad146acda98547f53b4dd23ac6ef8c9d",
+    "wof:geomhash":"81cee63f340bbf475ec36a8ea3fb7f2b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108692395,
-    "wof:lastmodified":1690854196,
+    "wof:lastmodified":1695886674,
     "wof:name":"Sukkur",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/239/7/1108692397.geojson
+++ b/data/110/869/239/7/1108692397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143351,
-    "geom:area_square_m":1467149175.444405,
+    "geom:area_square_m":1467149175.44446,
     "geom:bbox":"72.2018121245,33.9349905219,72.76954632,34.3861245685",
     "geom:latitude":34.136895,
     "geom:longitude":72.462266,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319956,
-    "wof:geomhash":"ba7c8f751e701349fcc747accd150db3",
+    "wof:geomhash":"b34697d1f742e5d991a9e18981e3e854",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692397,
-    "wof:lastmodified":1566590172,
+    "wof:lastmodified":1695886674,
     "wof:name":"Swabi",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/239/9/1108692399.geojson
+++ b/data/110/869/239/9/1108692399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.531615,
-    "geom:area_square_m":5368477261.841915,
+    "geom:area_square_m":5368476094.734131,
     "geom:bbox":"72.092161,34.569532,72.795343,35.914945",
     "geom:latitude":35.244571,
     "geom:longitude":72.465497,
@@ -103,9 +103,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319958,
-    "wof:geomhash":"83354bb5021439f7722abbd9f09665e4",
+    "wof:geomhash":"77c9eed4b8972e0fa5912588c84eaf40",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692399,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886159,
     "wof:name":"Swat",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/240/1/1108692401.geojson
+++ b/data/110/869/240/1/1108692401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141133,
-    "geom:area_square_m":1575603227.222717,
+    "geom:area_square_m":1575603887.381166,
     "geom:bbox":"68.577412,25.207057,68.998827,25.761607",
     "geom:latitude":25.464219,
     "geom:longitude":68.782391,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2419054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319959,
-    "wof:geomhash":"58de69c2d0e56ac4fd12b40590c8bb65",
+    "wof:geomhash":"fadf3b04606bec95b075049443aeba55",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692401,
-    "wof:lastmodified":1690854192,
+    "wof:lastmodified":1695886672,
     "wof:name":"Tando Allah Yar",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/240/3/1108692403.geojson
+++ b/data/110/869/240/3/1108692403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137788,
-    "geom:area_square_m":1544067506.416321,
+    "geom:area_square_m":1544067244.077036,
     "geom:bbox":"68.254798,24.757014,68.75344,25.290654",
     "geom:latitude":25.006075,
     "geom:longitude":68.478868,
@@ -122,9 +122,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2419054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319960,
-    "wof:geomhash":"34dcb0e5fa122a105c14fc7e1babc594",
+    "wof:geomhash":"8ea45f878aedaec086caf92102b5e900",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108692403,
-    "wof:lastmodified":1690854192,
+    "wof:lastmodified":1695886672,
     "wof:name":"Tando Muhammad Khan",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/240/7/1108692407.geojson
+++ b/data/110/869/240/7/1108692407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157643,
-    "geom:area_square_m":1648645845.623953,
+    "geom:area_square_m":1648645082.678966,
     "geom:bbox":"70.077762,31.977706,70.708365,32.508723",
     "geom:latitude":32.245268,
     "geom:longitude":70.391477,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.NW.DI",
         "wd:id":"Q10955614"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319962,
-    "wof:geomhash":"3ca849be72074edb9863ec9a36d430c5",
+    "wof:geomhash":"4912a8bee6ad0825b56e3b18f1f0e6b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692407,
-    "wof:lastmodified":1690854192,
+    "wof:lastmodified":1695886671,
     "wof:name":"Tank",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/240/9/1108692409.geojson
+++ b/data/110/869/240/9/1108692409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.752012,
-    "geom:area_square_m":19668326591.973782,
+    "geom:area_square_m":19668326156.650459,
     "geom:bbox":"69.044187,24.17103,71.12577,25.719986",
     "geom:latitude":24.783275,
     "geom:longitude":70.184054,
@@ -131,9 +131,10 @@
         "hasc:id":"PK.SD.MK",
         "wd:id":"Q2315507"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319963,
-    "wof:geomhash":"83f5c52023baf756273aa830bfce1c7b",
+    "wof:geomhash":"960c9ee3b950c2952b3eceb1d52f12f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108692409,
-    "wof:lastmodified":1690854191,
+    "wof:lastmodified":1695886671,
     "wof:name":"Tharparkar",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/241/1/1108692411.geojson
+++ b/data/110/869/241/1/1108692411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.725323,
-    "geom:area_square_m":8146364375.288868,
+    "geom:area_square_m":8146364304.258068,
     "geom:bbox":"67.107918,23.947861,68.360848,25.447346",
     "geom:latitude":24.72578,
     "geom:longitude":67.733695,
@@ -113,9 +113,10 @@
         "hasc:id":"PK.SD.HD",
         "wd:id":"Q2419234"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319965,
-    "wof:geomhash":"ef48e86b69bf7cf75fe71b4a7ee36e4e",
+    "wof:geomhash":"97e4dc9618dd964e89401b1b9830e20b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108692411,
-    "wof:lastmodified":1690854189,
+    "wof:lastmodified":1695886669,
     "wof:name":"Thatta",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/241/3/1108692413.geojson
+++ b/data/110/869/241/3/1108692413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.295036,
-    "geom:area_square_m":3131071160.142681,
+    "geom:area_square_m":3131071160.142636,
     "geom:bbox":"72.1562440227,30.539304678,72.8577457501,31.3527622342",
     "geom:latitude":30.878041,
     "geom:longitude":72.550541,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.FS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319966,
-    "wof:geomhash":"5635f09a0912a412a9e98afe7cb2cdae",
+    "wof:geomhash":"5e574f2a8f4a6bcbe4948e71566fabc1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692413,
-    "wof:lastmodified":1566590161,
+    "wof:lastmodified":1695886670,
     "wof:name":"Toba Tek Singh",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/241/5/1108692415.geojson
+++ b/data/110/869/241/5/1108692415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045483,
-    "geom:area_square_m":463176411.469622,
+    "geom:area_square_m":463175678.39133,
     "geom:bbox":"72.715081,34.331727,72.9397,34.787116",
     "geom:latitude":34.5565,
     "geom:longitude":72.830576,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.HZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319968,
-    "wof:geomhash":"dc9ae5c68cd63d3382509dc52783a470",
+    "wof:geomhash":"7f7957954529d09153f33ce481d13cef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692415,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886159,
     "wof:name":"Tor Ghar",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/241/7/1108692417.geojson
+++ b/data/110/869/241/7/1108692417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.493998,
-    "geom:area_square_m":5518330168.343703,
+    "geom:area_square_m":5518330168.343678,
     "geom:bbox":"69.1483830488,24.8644020508,70.3194411314,25.7967028405",
     "geom:latitude":25.390289,
     "geom:longitude":69.779812,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"PK.SD.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319969,
-    "wof:geomhash":"7def765953c70e285665aa9d92a97e50",
+    "wof:geomhash":"3389ad908b76a7bf319ad8110fe6b9f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108692417,
-    "wof:lastmodified":1566590160,
+    "wof:lastmodified":1695886669,
     "wof:name":"Umerkot",
     "wof:parent_id":85675757,
     "wof:placetype":"county",

--- a/data/110/869/241/9/1108692419.geojson
+++ b/data/110/869/241/9/1108692419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.370847,
-    "geom:area_square_m":3743225855.888875,
+    "geom:area_square_m":3743227309.474852,
     "geom:bbox":"71.53093,34.829926,72.370032,35.79046",
     "geom:latitude":35.283238,
     "geom:longitude":72.036042,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"PK.NW.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319971,
-    "wof:geomhash":"cf566b6cc47b97bb8a73ed14990473c4",
+    "wof:geomhash":"4b8490f06ca95b801487987f404b82e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108692419,
-    "wof:lastmodified":1627522515,
+    "wof:lastmodified":1695886159,
     "wof:name":"Upper Dir",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/110/869/242/1/1108692421.geojson
+++ b/data/110/869/242/1/1108692421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.427676,
-    "geom:area_square_m":4579370999.381886,
+    "geom:area_square_m":4579370999.381681,
     "geom:bbox":"71.7369827287,29.575069517,72.9852929237,30.3739788923",
     "geom:latitude":30.009,
     "geom:longitude":72.411237,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"PK.PB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319972,
-    "wof:geomhash":"ccc24cc33e8a393ce0dbfcb20b6e8c9e",
+    "wof:geomhash":"d9d4d91d7521c630a9061dbc849eeaa1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692421,
-    "wof:lastmodified":1566590152,
+    "wof:lastmodified":1695886668,
     "wof:name":"Vehari",
     "wof:parent_id":85675753,
     "wof:placetype":"county",

--- a/data/110/869/242/5/1108692425.geojson
+++ b/data/110/869/242/5/1108692425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.347448,
-    "geom:area_square_m":36631950251.387657,
+    "geom:area_square_m":36631952146.636185,
     "geom:bbox":"62.774983,26.888877,65.998527,28.708331",
     "geom:latitude":27.745835,
     "geom:longitude":64.346998,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.KL",
         "wd:id":"Q537334"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319973,
-    "wof:geomhash":"0015a16126d2d01c2f05f6b7ed532f72",
+    "wof:geomhash":"9060db3de61ba0da832bb48c122c651b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692425,
-    "wof:lastmodified":1690854184,
+    "wof:lastmodified":1695886668,
     "wof:name":"Washuk",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/110/869/242/7/1108692427.geojson
+++ b/data/110/869/242/7/1108692427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.304629,
-    "geom:area_square_m":3249245808.767363,
+    "geom:area_square_m":3249247559.368695,
     "geom:bbox":"67.188792,30.150589,68.574988,30.593223",
     "geom:latitude":30.389926,
     "geom:longitude":67.88415,
@@ -116,9 +116,10 @@
         "hasc:id":"PK.BA.ZH",
         "wd:id":"Q2281268"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1474319976,
-    "wof:geomhash":"efd559c55d8331e23ab93dbf0ca8d9c4",
+    "wof:geomhash":"01844e95c48f311047160038c505284f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108692427,
-    "wof:lastmodified":1690854183,
+    "wof:lastmodified":1695886668,
     "wof:name":"Ziarat",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/136/070/100/1/1360701001.geojson
+++ b/data/136/070/100/1/1360701001.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"2010-04-15",
     "geom:area":10.008672,
-    "geom:area_square_m":102411327817.488937,
+    "geom:area_square_m":102411330761.235992,
     "geom:bbox":"69.228001,31.065753,74.124705,36.896638",
     "geom:latitude":34.1312,
     "geom:longitude":71.632493,
@@ -410,14 +410,16 @@
         "gn:id":1168873,
         "gp:id":2346497,
         "hasc:id":"PK.NW",
+        "iso:code":"PK-KP",
         "iso:id":"PK-KP",
         "nyt:id":"N37367185912177872091",
         "qs_pg:id":423864,
         "wd:id":"Q183314",
         "wk:page":"Khyber Pakhtunkhwa"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PK",
-    "wof:geomhash":"eed62b145c32610bde948d354337ef8f",
+    "wof:geomhash":"1f5b18d711f4bd6653468920b5c92ff3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -434,7 +436,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854204,
+    "wof:lastmodified":1695884324,
     "wof:name":"Khyber Pakhtunkhwa",
     "wof:parent_id":85632659,
     "wof:placetype":"region",

--- a/data/856/326/59/85632659.geojson
+++ b/data/856/326/59/85632659.geojson
@@ -1223,6 +1223,7 @@
         "hasc:id":"PK",
         "icao:code":"AP",
         "ioc:id":"PAK",
+        "iso:code":"PK",
         "itu:id":"PAK",
         "loc:id":"n80125947",
         "m49:code":"586",
@@ -1237,6 +1238,7 @@
         "wk:page":"Pakistan",
         "wmo:id":"PK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PK",
     "wof:country_alpha3":"PAK",
     "wof:geom_alt":[
@@ -1262,7 +1264,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1694639635,
+    "wof:lastmodified":1695881297,
     "wof:name":"Pakistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/757/33/85675733.geojson
+++ b/data/856/757/33/85675733.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1947-08-14",
     "geom:area":32.032526,
-    "geom:area_square_m":348529012248.522949,
+    "geom:area_square_m":348529014240.572449,
     "geom:bbox":"60.844379,24.892035,70.258172,32.061144",
     "geom:latitude":28.317609,
     "geom:longitude":65.868846,
@@ -431,6 +431,7 @@
         "gn:id":1183606,
         "gp:id":2346496,
         "hasc:id":"PK.BA",
+        "iso:code":"PK-BA",
         "iso:id":"PK-BA",
         "nyt:id":"19835038768305085181",
         "qs_pg:id":423863,
@@ -438,8 +439,9 @@
         "wd:id":"Q163239",
         "wk:page":"Balochistan, Pakistan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PK",
-    "wof:geomhash":"b814e440b9ca49e9d2540f63e0da6a6a",
+    "wof:geomhash":"403d9869c77f3f1299a2dd3ed99c6d4b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -456,7 +458,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854151,
+    "wof:lastmodified":1695884324,
     "wof:name":"Balochistan",
     "wof:parent_id":85632659,
     "wof:placetype":"region",

--- a/data/856/757/35/85675735.geojson
+++ b/data/856/757/35/85675735.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1947-10-24",
     "geom:area":1.210751,
-    "geom:area_square_m":12397173100.410032,
+    "geom:area_square_m":12397172268.023411,
     "geom:bbox":"73.400201,32.823067,75.255295,35.123654",
     "geom:latitude":34.094219,
     "geom:longitude":74.018804,
@@ -404,12 +404,14 @@
         "gn:id":1184196,
         "gp:id":2346500,
         "hasc:id":"PK.JK",
+        "iso:code":"PK-JK",
         "iso:id":"PK-JK",
         "qs_pg:id":423866,
         "unlc:id":"PK-JK",
         "wd:id":"Q200130",
         "wk:page":"Azad Kashmir"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:country",
@@ -419,7 +421,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"41a54eeb9edd31bfef86698bf3f1f71c",
+    "wof:geomhash":"e9b918a43e379b97071e02406635964a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -443,7 +445,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854150,
+    "wof:lastmodified":1695884920,
     "wof:name":"Azad Kashmir",
     "wof:parent_id":1159339497,
     "wof:placetype":"region",

--- a/data/856/757/41/85675741.geojson
+++ b/data/856/757/41/85675741.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1960",
     "geom:area":0.084208,
-    "geom:area_square_m":866675806.157003,
+    "geom:area_square_m":866676088.792073,
     "geom:bbox":"72.804993,33.492271,73.320517,33.804345",
     "geom:latitude":33.659599,
     "geom:longitude":73.084992,
@@ -247,17 +247,19 @@
         "gn:id":1162015,
         "gp:id":20070149,
         "hasc:id":"PK.IS",
+        "iso:code":"PK-IS",
         "iso:id":"PK-IS",
         "qs_pg:id":219911,
         "unlc:id":"PK-IS",
         "wd:id":"Q848613",
         "wk:page":"Islamabad Capital Territory"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421168811
     ],
     "wof:country":"PK",
-    "wof:geomhash":"542fee2a1c692e390f675dc4c16f0b23",
+    "wof:geomhash":"0e393378b18098894865f3b552407f52",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -274,7 +276,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854152,
+    "wof:lastmodified":1695884324,
     "wof:name":"Islamabad",
     "wof:parent_id":85632659,
     "wof:placetype":"region",

--- a/data/856/757/45/85675745.geojson
+++ b/data/856/757/45/85675745.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1948-11-01",
     "geom:area":6.538208,
-    "geom:area_square_m":65548019556.009903,
+    "geom:area_square_m":65548018779.027863,
     "geom:bbox":"72.515604,34.51061,77.010051,37.084107",
     "geom:latitude":35.822739,
     "geom:longitude":74.887772,
@@ -383,16 +383,18 @@
         "gn:id":1168878,
         "gp:id":2346501,
         "hasc:id":"PK.NA",
+        "iso:code":"PK-GB",
         "iso:id":"PK-GB",
         "qs_pg:id":423868,
         "wd:id":"Q200697",
         "wk:page":"Gilgit-Baltistan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a62d8d882a3472209c5d3ca6476d8c6d",
+    "wof:geomhash":"f5b7419e41a4ecc3a893c8068237b04b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -416,7 +418,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854151,
+    "wof:lastmodified":1695885131,
     "wof:name":"Gilgit-Baltistan",
     "wof:parent_id":1159339495,
     "wof:placetype":"region",

--- a/data/856/757/53/85675753.geojson
+++ b/data/856/757/53/85675753.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1970-07-01",
     "geom:area":19.223144,
-    "geom:area_square_m":204054041411.903259,
+    "geom:area_square_m":204054039665.28421,
     "geom:bbox":"69.330993,27.701463,75.359048,34.022781",
     "geom:latitude":30.821965,
     "geom:longitude":72.134147,
@@ -438,6 +438,7 @@
         "gn:id":1167710,
         "gp:id":2346498,
         "hasc:id":"PK.PB",
+        "iso:code":"PK-PB",
         "iso:id":"PK-PB",
         "nyt:id":"71010102219428544521",
         "qs_pg:id":1168712,
@@ -445,8 +446,9 @@
         "wd:id":"Q4478",
         "wk:page":"Punjab, Pakistan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PK",
-    "wof:geomhash":"8545f766bd2d6829af11d3a60c320640",
+    "wof:geomhash":"e3e5e3c5fa0c58cd129bed6913c005a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -463,7 +465,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854152,
+    "wof:lastmodified":1695884324,
     "wof:name":"Punjab",
     "wof:parent_id":85632659,
     "wof:placetype":"region",

--- a/data/856/757/57/85675757.geojson
+++ b/data/856/757/57/85675757.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1970-07-01",
     "geom:area":12.686222,
-    "geom:area_square_m":140926356896.94809,
+    "geom:area_square_m":140926359988.758209,
     "geom:bbox":"66.654145,23.694525,71.082772,28.52844",
     "geom:latitude":26.027407,
     "geom:longitude":68.768081,
@@ -452,14 +452,16 @@
         "gn:id":1164807,
         "gp:id":2346499,
         "hasc:id":"PK.SD",
+        "iso:code":"PK-SD",
         "iso:id":"PK-SD",
         "qs_pg:id":423865,
         "unlc:id":"PK-SD",
         "wd:id":"Q37211",
         "wk:page":"Sindh"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PK",
-    "wof:geomhash":"6ba61a0c889761f234881d1d9a3ce667",
+    "wof:geomhash":"35a30030fe329ac4c03d149c2919b1ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -476,7 +478,7 @@
         "urd",
         "eng"
     ],
-    "wof:lastmodified":1690854150,
+    "wof:lastmodified":1695884324,
     "wof:name":"Sindh",
     "wof:parent_id":85632659,
     "wof:placetype":"region",

--- a/data/890/420/091/890420091.geojson
+++ b/data/890/420/091/890420091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.759505,
-    "geom:area_square_m":8108200520.090469,
+    "geom:area_square_m":8108198533.020167,
     "geom:bbox":"67.674826,29.906228,69.756523,30.705395",
     "geom:latitude":30.303371,
     "geom:longitude":68.900335,
@@ -134,12 +134,13 @@
         "wd:id":"Q2281268",
         "wk:page":"Loralai District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1469051317,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6469e7e99c8adf79f3a09fe363adf0fa",
+    "wof:geomhash":"0513f142aa3a8f4509652f6767bea396",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":890420091,
-    "wof:lastmodified":1690854278,
+    "wof:lastmodified":1695886795,
     "wof:name":"Loralai",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/890/422/345/890422345.geojson
+++ b/data/890/422/345/890422345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.473625,
-    "geom:area_square_m":4914170679.322829,
+    "geom:area_square_m":4914170679.324501,
     "geom:bbox":"69.387605,32.5625185776,70.6280904525,33.3535189761",
     "geom:latitude":32.954245,
     "geom:longitude":69.981552,
@@ -123,12 +123,13 @@
         "hasc:id":"PK.TA.TA",
         "qs_pg:id":555299
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1469051438,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff3934462b3affec437f5ab9edd80df9",
+    "wof:geomhash":"d6eef37d0316d153f3ab8d8c1e51b07d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":890422345,
-    "wof:lastmodified":1582351713,
+    "wof:lastmodified":1695886795,
     "wof:name":"North Waziristan",
     "wof:parent_id":1360701001,
     "wof:placetype":"county",

--- a/data/890/438/109/890438109.geojson
+++ b/data/890/438/109/890438109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.260015,
-    "geom:area_square_m":2779971398.541859,
+    "geom:area_square_m":2779969252.340341,
     "geom:bbox":"66.228985,29.80226,67.293863,30.476932",
     "geom:latitude":30.156866,
     "geom:longitude":66.765845,
@@ -145,12 +145,13 @@
         "wd:id":"Q2315549",
         "wk:page":"Quetta District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1469052180,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ecddd5b86ea638c4fa0e26605f1cc923",
+    "wof:geomhash":"e3a8b53477496f333fe55a0918b34e58",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":890438109,
-    "wof:lastmodified":1690854276,
+    "wof:lastmodified":1695886796,
     "wof:name":"Quetta",
     "wof:parent_id":85675733,
     "wof:placetype":"county",

--- a/data/890/455/843/890455843.geojson
+++ b/data/890/455/843/890455843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.139302,
-    "geom:area_square_m":12028129677.79291,
+    "geom:area_square_m":12028130883.0891,
     "geom:bbox":"67.814288,30.474887,69.742413,31.967842",
     "geom:latitude":31.370729,
     "geom:longitude":69.018484,
@@ -136,12 +136,13 @@
         "wd:id":"Q2281313",
         "wk:page":"Zhob District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PK",
     "wof:created":1469052977,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa0d0938c5e5bc455f7fa44ce808405b",
+    "wof:geomhash":"79289e2fdaf6c3b887575453e8745f7e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":890455843,
-    "wof:lastmodified":1690854274,
+    "wof:lastmodified":1695886043,
     "wof:name":"Zhob",
     "wof:parent_id":85675733,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.